### PR TITLE
add log paths to our brew service

### DIFF
--- a/Formula/viam-server.rb
+++ b/Formula/viam-server.rb
@@ -32,6 +32,8 @@ class ViamServer < Formula
   end
 
   service do
+    log_path var/"log/viam.log"
+    error_log_path var/"log/viam.log"
     run [bin/"viam-server", "-config", etc/"viam.json"]
   end
 


### PR DESCRIPTION
did the following testing and this seems to work:

1. put the formula manually in the path
2. brew remove viam-server
3. brew install dannenserver (i'd renamed it)
4. start the service
5. see logs in the appropriate path