### PR TITLE
[DATA-605] Orbslam homebrew formula

### DIFF
--- a/Formula/orb-grpc-server.rb
+++ b/Formula/orb-grpc-server.rb
@@ -1,8 +1,9 @@
 class OrbGrpcServer < Formula
   desc "A Viam slam GRPC server for ORB_SLAM3"
   homepage "https://www.viam.com/"
-  url "https://github.com/viamrobotics/slam/archive/refs/tags/v0.1.4.tar.gz"
-  sha256 "26af8f02105cb2bfe3c8f3e6ba9b73100ea8d77098d58a535b1e2d4c56bb907c"
+  url "https://github.com/viamrobotics/slam.git",
+    tag: "v0.1.5",
+    revision: "392d8bcdc1b122c35d0a5f8c15b2b2a2eb2fd0f3"
   license "Apache-2.0"
   head "https://github.com/viamrobotics/slam.git", branch: "main"
 
@@ -21,6 +22,13 @@ class OrbGrpcServer < Formula
     chdir "slam-libraries" do
       system "make", "buf"
       system "make", "buildorb"
+      if OS.mac?
+        system "install_name_tool", "-change", buildpath.to_s.delete_prefix("/private") + "/slam-libraries/viam-orb-slam3/ORB_SLAM3/Thirdparty/DBoW2/lib/libDBoW2.dylib", "#{lib}/libDBoW2.dylib", "viam-orb-slam3/ORB_SLAM3/lib/libORB_SLAM3.dylib"
+        system "install_name_tool", "-change", buildpath.to_s.delete_prefix("/private") + "/slam-libraries/viam-orb-slam3/ORB_SLAM3/Thirdparty/g2o/lib/libg2o.dylib", "#{lib}/libg2o.dylib", "viam-orb-slam3/ORB_SLAM3/lib/libORB_SLAM3.dylib"
+        system "install_name_tool", "-change", buildpath.to_s.delete_prefix("/private") + "/slam-libraries/viam-orb-slam3/ORB_SLAM3/Thirdparty/DBoW2/lib/libDBoW2.dylib", "#{lib}/libDBoW2.dylib", "viam-orb-slam3/bin/orb_grpc_server"
+        system "install_name_tool", "-change", buildpath.to_s.delete_prefix("/private") + "/slam-libraries/viam-orb-slam3/ORB_SLAM3/Thirdparty/g2o/lib/libg2o.dylib", "#{lib}/libg2o.dylib", "viam-orb-slam3/bin/orb_grpc_server"
+        system "install_name_tool", "-change", buildpath.to_s.delete_prefix("/private") + "/slam-libraries/viam-orb-slam3/ORB_SLAM3/lib/libORB_SLAM3.dylib", "#{lib}/libORB_SLAM3.dylib", "viam-orb-slam3/bin/orb_grpc_server"
+      end
       bin.install "viam-orb-slam3/bin/orb_grpc_server"
       lib.install Dir["viam-orb-slam3/ORB_SLAM3/lib/*"]
       lib.install Dir["viam-orb-slam3/ORB_SLAM3/Thirdparty/DBoW2/lib/*"]

--- a/Formula/orb-grpc-server.rb
+++ b/Formula/orb-grpc-server.rb
@@ -4,7 +4,7 @@ class OrbGrpcServer < Formula
   url "https://github.com/viamrobotics/slam/archive/refs/tags/v0.1.4.tar.gz"
   sha256 "26af8f02105cb2bfe3c8f3e6ba9b73100ea8d77098d58a535b1e2d4c56bb907c"
   license "Apache-2.0"
-  head "https://github.com/viamrobotics/slam.git", branch: "DATA-605"
+  head "https://github.com/viamrobotics/slam.git", branch: "main"
 
   depends_on "pkg-config" => :build
   depends_on "go" => :build

--- a/Formula/orb-grpc-server.rb
+++ b/Formula/orb-grpc-server.rb
@@ -1,0 +1,32 @@
+class OrbGrpcServer < Formula
+  desc "A Viam slam GRPC server for ORB_SLAM3"
+  homepage "https://www.viam.com/"
+  url "https://github.com/viamrobotics/slam/archive/refs/tags/v0.1.4.tar.gz"
+  sha256 "26af8f02105cb2bfe3c8f3e6ba9b73100ea8d77098d58a535b1e2d4c56bb907c"
+  license "Apache-2.0"
+  head "https://github.com/tessavitabile/slam.git", branch: "DATA-605"
+
+  depends_on "pkg-config" => :build
+  depends_on "go" => :build
+  depends_on "cmake" => :build
+  depends_on "grpc"
+  depends_on "glew"
+  depends_on "opencv@4"
+  depends_on "eigen"
+  depends_on "boost"
+  depends_on "openssl"
+  depends_on "pangolin"
+
+  def install
+    chdir "slam-libraries" do
+      system "make", "buf"
+      system "make", "buildorb"
+      bin.install "viam-orb-slam3/bin/orb_grpc_server"
+      lib.install Dir["viam-orb-slam3/ORB_SLAM3/lib/*"]
+      lib.install Dir["viam-orb-slam3/ORB_SLAM3/Thirdparty/DBoW2/lib/*"]
+      lib.install Dir["viam-orb-slam3/ORB_SLAM3/Thirdparty/g2o/lib/*"]
+      (share/"orbslam/Vocabulary").mkpath
+      share.install "viam-orb-slam3/ORB_SLAM3/Vocabulary/ORBvoc.txt" => "orbslam/Vocabulary/ORBvoc.txt"
+    end
+  end
+end

--- a/Formula/orb-grpc-server.rb
+++ b/Formula/orb-grpc-server.rb
@@ -4,7 +4,7 @@ class OrbGrpcServer < Formula
   url "https://github.com/viamrobotics/slam/archive/refs/tags/v0.1.4.tar.gz"
   sha256 "26af8f02105cb2bfe3c8f3e6ba9b73100ea8d77098d58a535b1e2d4c56bb907c"
   license "Apache-2.0"
-  head "https://github.com/tessavitabile/slam.git", branch: "DATA-605"
+  head "https://github.com/viamrobotics/slam.git", branch: "DATA-605"
 
   depends_on "pkg-config" => :build
   depends_on "go" => :build


### PR DESCRIPTION
https://viam.atlassian.net/browse/DATA-605

A couple questions:
- After running `brew install`, I still had to manually link everything from `/opt/homebrew/Cellar/orb-grpc-server/HEAD-af2dec0/lib/` into `/usr/local/lib/`. Otherwise, I got a runtime error:
`dyld[13090]: Library not loaded: /tmp/orb-grpc-server-20221026-10229-f8sjnr/slam-libraries/viam-orb-slam3/ORB_SLAM3/Thirdparty/DBoW2/lib/libDBoW2.dylib
  Referenced from: /opt/homebrew/Cellar/orb-grpc-server/HEAD-af2dec0/bin/orb_grpc_server
  Reason: tried: '/tmp/orb-grpc-server-20221026-10229-f8sjnr/slam-libraries/viam-orb-slam3/ORB_SLAM3/Thirdparty/DBoW2/lib/libDBoW2.dylib' (no such file), '/usr/local/lib/libDBoW2.dylib' (no such file), '/usr/lib/libDBoW2.dylib' (no such file)`
I'm not sure if this is a problem with HEAD installs, or a problem with the brew formula that I wrote. Any advice?
**EDIT**: Now that I recall, I had the same problem when I installed `pangolin` using the brew package.
- I tested on my M1. Do we have access to an intel mac to test on?
**UPDATE**: Kat and I tested on her intel mac, and the behavior was mostly the same as on my M1 mac. Yay! The only difference was that on my mac, the binary was installed to `/opt/homebrew/bin`, so `which orb_grpc_server` returned something. On Kat's mac, the binary wasn't linked to any location that we found, so `which orb_grpc_server` returned nothing. We tested by running the binary in the Cellar directly.