### PR TITLE
RSDK-778 - include tag version

### DIFF
--- a/Formula/viam-server.rb
+++ b/Formula/viam-server.rb
@@ -14,7 +14,11 @@ class ViamServer < Formula
   depends_on "ffmpeg"
 
   def install
-    system "make", "server"
+    with_env(
+      "TAG_VERSION" => "v#{version.to_s}"
+    ) do
+      system "make", "server"
+    end
     if OS.linux?
       if Hardware::CPU.intel?
         bin.install "bin/Linux-x86_64/server" => "viam-server"


### PR DESCRIPTION
This uses https://github.com/viamrobotics/rdk/pull/1700 to include a tag version in brew based builds.

TODO: Bump to latest tag, after dependent PR merged in.