### PR TITLE
[RSDK-804] Automatically bump homebrew versions

### DIFF
--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -23,12 +23,13 @@ jobs:
       with:
         ref: ${{ github.head_ref }}
 
-    - name: Setup homebrew tap and git config
+    - name: Setup homebrew and git config
       run: |
         mkdir /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/viamrobotics
         ln -s $(pwd) /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/viamrobotics/homebrew-brews
         git config --global --add safe.directory '*'
         git config --global url."https://github.com/".insteadOf git@github.com:
+        brew developer on
 
     - name: Bump viam-server
       run: ./bump-version.sh viam-server

--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -15,7 +15,7 @@ jobs:
     #runs-on: [x64, qemu-host]
     runs-on: ubuntu-latest
     container:
-      image: homebrew/brews
+      image: homebrew/brew
     timeout-minutes: 10
     steps:
     - name: Check out code

--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -24,11 +24,12 @@ jobs:
       with:
         ref: ${{ github.head_ref }}
 
-    - name: Link brew tap
+    - name: Setup homebrew tap and git config
       run: |
         mkdir /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/viamrobotics
         ln -s $(pwd) /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/viamrobotics/homebrew-brews
         git config --global --add safe.directory '*'
+        git config --global url."https://github.com/".insteadOf git@github.com:
 
     - name: Bump viam-server
       run: ./bump-version.sh viam-server

--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -28,8 +28,7 @@ jobs:
       run: |
         mkdir /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/viamrobotics
         ln -s $(pwd) /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/viamrobotics/homebrew-brews
-        git config --global --add safe.directory "$GITHUB_WORKSPACE"
-        git config --global --add safe.directory /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/viamrobotics/homebrew-brews
+        git config --global --add safe.directory '*'
 
     - name: Bump viam-server
       run: ./bump-version.sh viam-server

--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -24,8 +24,8 @@ jobs:
 
     - name: Link brew tap
       run: |
-        mkdir /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/Otterverse
-        ln -s $(pwd) /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/Otterverse/homebrew-brews
+        mkdir /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/viamrobotics
+        ln -s $(pwd) /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/viamrobitics/homebrew-brews
 
     - name: Bump viam-server
       run: ./bump-version.sh viam-server

--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@v3
+      with:
+        ref: ${{ github.head_ref }}
 
     - name: Link brew tap
       run: |

--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -28,6 +28,8 @@ jobs:
       run: |
         mkdir /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/viamrobotics
         ln -s $(pwd) /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/viamrobotics/homebrew-brews
+        git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        git config --global --add safe.directory /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/viamrobotics/homebrew-brews
 
     - name: Bump viam-server
       run: ./bump-version.sh viam-server

--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -12,13 +12,15 @@ on:
 jobs:
   bump-versions:
     name: Bump Package Versions
-    runs-on: [x64, qemu-host]
+    #runs-on: [x64, qemu-host]
+    runs-on: ubuntu-latest
     container:
       image: homebrew/brews
     timeout-minutes: 10
     steps:
     - name: Check out code
       uses: actions/checkout@v3
+
     - name: Link brew tap
       run: |
         mkdir /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/Otterverse
@@ -34,6 +36,6 @@ jobs:
       run: ./bump-version.sh orb-grpc-server
 
     - name: Commit changes
-    - uses: stefanzweifel/git-auto-commit-action@v4
+      uses: stefanzweifel/git-auto-commit-action@v4
       with:
         commit_message: Auto-update of package versions

--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -1,0 +1,39 @@
+name: Bump Versions
+
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  schedule:
+    - cron: '0 * * * *' # hourly
+  workflow_dispatch:
+
+jobs:
+  bump-versions:
+    name: Bump Package Versions
+    runs-on: [x64, qemu-host]
+    container:
+      image: homebrew/brews
+    timeout-minutes: 10
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v3
+    - name: Link brew tap
+      run: |
+        mkdir /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/Otterverse
+        ln -s $(pwd) /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/Otterverse/homebrew-brews
+
+    - name: Bump viam-server
+      run: ./bump-version.sh viam-server
+
+    - name: Bump carto-grpc-server
+      run: ./bump-version.sh carto-grpc-server
+
+    - name: Bump orb-grpc-server
+      run: ./bump-version.sh orb-grpc-server
+
+    - name: Commit changes
+    - uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+        commit_message: Auto-update of package versions

--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -12,7 +12,6 @@ on:
 jobs:
   bump-versions:
     name: Bump Package Versions
-    #runs-on: [x64, qemu-host]
     runs-on: ubuntu-latest
     container:
       image: homebrew/brew

--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Link brew tap
       run: |
         mkdir /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/viamrobotics
-        ln -s $(pwd) /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/viamrobitics/homebrew-brews
+        ln -s $(pwd) /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/viamrobotics/homebrew-brews
 
     - name: Bump viam-server
       run: ./bump-version.sh viam-server

--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: homebrew/brew
+      options: --user root
     timeout-minutes: 10
     steps:
     - name: Check out code

--- a/Formula/aravis-cli.rb
+++ b/Formula/aravis-cli.rb
@@ -22,5 +22,4 @@ class AravisCli < Formula
       system "ninja", "install"
     end
   end
-
 end

--- a/Formula/carto-grpc-server.rb
+++ b/Formula/carto-grpc-server.rb
@@ -2,8 +2,8 @@ class CartoGrpcServer < Formula
   desc "A Viam slam GRPC server for Cartographer"
   homepage "https://www.viam.com/"
   url "https://github.com/viamrobotics/slam.git",
-    tag: "v0.1.14",
-    revision: "3d5e5c3b3e844d4a25d16d7a1d9dfffcfa0fb14b"
+    tag: "v0.1.12",
+    revision: "99cce9033feaea095050ab78a4a27371aaa88956"
   license "Apache-2.0"
   head "https://github.com/viamrobotics/slam.git", branch: "main"
 

--- a/Formula/carto-grpc-server.rb
+++ b/Formula/carto-grpc-server.rb
@@ -2,8 +2,8 @@ class CartoGrpcServer < Formula
   desc "A Viam slam GRPC server for Cartographer"
   homepage "https://www.viam.com/"
   url "https://github.com/viamrobotics/slam.git",
-    tag: "v0.1.12",
-    revision: "99cce9033feaea095050ab78a4a27371aaa88956"
+    tag: "v0.1.14",
+    revision: "3d5e5c3b3e844d4a25d16d7a1d9dfffcfa0fb14b"
   license "Apache-2.0"
   head "https://github.com/viamrobotics/slam.git", branch: "main"
 

--- a/Formula/carto-grpc-server.rb
+++ b/Formula/carto-grpc-server.rb
@@ -40,7 +40,7 @@ class CartoGrpcServer < Formula
       share.install "viam-cartographer/lua_files/updating_a_map.lua" => "cartographer/lua_files/"
       share.install "viam-cartographer/cartographer/configuration_files/map_builder.lua" => "cartographer/lua_files/"
       share.install "viam-cartographer/cartographer/configuration_files/pose_graph.lua" => "cartographer/lua_files/"
-      share.install "viam-cartographer/cartographer/configuration_files/trajectory_builder_2d.lua" =>"cartographer/lua_files/"
+      share.install "viam-cartographer/cartographer/configuration_files/trajectory_builder_2d.lua" => "cartographer/lua_files/"
       share.install "viam-cartographer/cartographer/configuration_files/map_builder_server.lua" => "cartographer/lua_files/"
       share.install "viam-cartographer/cartographer/configuration_files/trajectory_builder.lua" => "cartographer/lua_files/"
       share.install "viam-cartographer/cartographer/configuration_files/trajectory_builder_3d.lua" => "cartographer/lua_files/"

--- a/Formula/carto-grpc-server.rb
+++ b/Formula/carto-grpc-server.rb
@@ -1,49 +1,49 @@
 class CartoGrpcServer < Formula
-  desc "A Viam slam GRPC server for Cartographer"
+  desc "Viam slam GRPC server for Cartographer"
   homepage "https://www.viam.com/"
   url "https://github.com/viamrobotics/slam.git",
-    tag: "v0.1.14",
+    tag:      "v0.1.14",
     revision: "3d5e5c3b3e844d4a25d16d7a1d9dfffcfa0fb14b"
   license "Apache-2.0"
   head "https://github.com/viamrobotics/slam.git", branch: "main"
 
-  depends_on "go" => :build
   depends_on "cmake" => :build
+  depends_on "go" => :build
   depends_on "ninja" => :build
   depends_on "abseil"
   depends_on "boost"
-  depends_on "ceres-solver"
-  depends_on "grpc"
-  depends_on "protobuf"
   depends_on "cairo"
-  depends_on "googletest"
-  depends_on "lua@5.3"
-  depends_on "openssl"
+  depends_on "ceres-solver"
   depends_on "eigen"
   depends_on "gflags"
   depends_on "glog"
-  depends_on "suite-sparse"
-  depends_on "sphinx-doc"
+  depends_on "googletest"
+  depends_on "grpc"
+  depends_on "lua@5.3"
+  depends_on "openssl"
   depends_on "pcl"
+  depends_on "protobuf"
+  depends_on "sphinx-doc"
+  depends_on "suite-sparse"
 
   def install
     chdir "slam-libraries" do
-        system "make", "buf"
-        system "make", "buildcarto"
-        
-        bin.install "viam-cartographer/build/carto_grpc_server"
-        lib.install "viam-cartographer/cartographer/build/libcartographer.a"
-        lib.install "viam-cartographer/build/libviam-cartographer.a"
-        (share/"cartographer/lua_files").mkpath
-        share.install "viam-cartographer/lua_files/locating_in_map.lua" => "cartographer/lua_files/"
-        share.install "viam-cartographer/lua_files/mapping_new_map.lua" => "cartographer/lua_files/"
-        share.install "viam-cartographer/lua_files/updating_a_map.lua" => "cartographer/lua_files/"
-        share.install "viam-cartographer/cartographer/configuration_files/map_builder.lua" => "cartographer/lua_files/"
-        share.install "viam-cartographer/cartographer/configuration_files/pose_graph.lua" => "cartographer/lua_files/"
-        share.install "viam-cartographer/cartographer/configuration_files/trajectory_builder_2d.lua" => "cartographer/lua_files/"
-        share.install "viam-cartographer/cartographer/configuration_files/map_builder_server.lua" => "cartographer/lua_files/"
-        share.install "viam-cartographer/cartographer/configuration_files/trajectory_builder.lua" => "cartographer/lua_files/"
-        share.install "viam-cartographer/cartographer/configuration_files/trajectory_builder_3d.lua" => "cartographer/lua_files/"
-      end
+      system "make", "buf"
+      system "make", "buildcarto"
+
+      bin.install "viam-cartographer/build/carto_grpc_server"
+      lib.install "viam-cartographer/cartographer/build/libcartographer.a"
+      lib.install "viam-cartographer/build/libviam-cartographer.a"
+      (share/"cartographer/lua_files").mkpath
+      share.install "viam-cartographer/lua_files/locating_in_map.lua" => "cartographer/lua_files/"
+      share.install "viam-cartographer/lua_files/mapping_new_map.lua" => "cartographer/lua_files/"
+      share.install "viam-cartographer/lua_files/updating_a_map.lua" => "cartographer/lua_files/"
+      share.install "viam-cartographer/cartographer/configuration_files/map_builder.lua" => "cartographer/lua_files/"
+      share.install "viam-cartographer/cartographer/configuration_files/pose_graph.lua" => "cartographer/lua_files/"
+      share.install "viam-cartographer/cartographer/configuration_files/trajectory_builder_2d.lua" =>"cartographer/lua_files/"
+      share.install "viam-cartographer/cartographer/configuration_files/map_builder_server.lua" => "cartographer/lua_files/"
+      share.install "viam-cartographer/cartographer/configuration_files/trajectory_builder.lua" => "cartographer/lua_files/"
+      share.install "viam-cartographer/cartographer/configuration_files/trajectory_builder_3d.lua" => "cartographer/lua_files/"
+    end
   end
 end

--- a/Formula/intel-real-grpc-server.rb
+++ b/Formula/intel-real-grpc-server.rb
@@ -1,17 +1,17 @@
 class IntelRealGrpcServer < Formula
-  desc "A Viam camera GRPC server for the Intel RealSense"
+  desc "Viam camera GRPC server for the Intel RealSense"
   homepage "https://www.viam.com/"
   url "https://github.com/viamrobotics/camera-servers/archive/refs/tags/v0.1.1.tar.gz"
   sha256 "4e872fb4ea1710c39c5919a4ed0f6e94d319853cd1ae546abf7eeebc9e87167e"
   license "Apache-2.0"
   head "https://github.com/viamrobotics/camera-servers.git", branch: "main"
 
-  depends_on "pkg-config" => :build
   depends_on "go" => :build
+  depends_on "pkg-config" => :build
   depends_on "grpc"
   depends_on "libhttpserver"
-  depends_on "opencv"
   depends_on "librealsense"
+  depends_on "opencv"
 
   def install
     system "make", "buf"

--- a/Formula/orb-grpc-server.rb
+++ b/Formula/orb-grpc-server.rb
@@ -2,8 +2,8 @@ class OrbGrpcServer < Formula
   desc "A Viam slam GRPC server for ORB_SLAM3"
   homepage "https://www.viam.com/"
   url "https://github.com/viamrobotics/slam.git",
-    tag: "v0.1.11",
-    revision: "28aba7cbee24f4e35b3a2edee8dc387a22461291"
+    tag: "v0.1.14",
+    revision: "3d5e5c3b3e844d4a25d16d7a1d9dfffcfa0fb14b"
   license "Apache-2.0"
   head "https://github.com/viamrobotics/slam.git", branch: "main"
 

--- a/Formula/orb-grpc-server.rb
+++ b/Formula/orb-grpc-server.rb
@@ -2,8 +2,8 @@ class OrbGrpcServer < Formula
   desc "A Viam slam GRPC server for ORB_SLAM3"
   homepage "https://www.viam.com/"
   url "https://github.com/viamrobotics/slam.git",
-    tag: "v0.1.14",
-    revision: "3d5e5c3b3e844d4a25d16d7a1d9dfffcfa0fb14b"
+    tag: "v0.1.11",
+    revision: "28aba7cbee24f4e35b3a2edee8dc387a22461291"
   license "Apache-2.0"
   head "https://github.com/viamrobotics/slam.git", branch: "main"
 

--- a/Formula/orb-grpc-server.rb
+++ b/Formula/orb-grpc-server.rb
@@ -1,20 +1,20 @@
 class OrbGrpcServer < Formula
-  desc "A Viam slam GRPC server for ORB_SLAM3"
+  desc "Viam slam GRPC server for ORB_SLAM3"
   homepage "https://www.viam.com/"
   url "https://github.com/viamrobotics/slam.git",
-    tag: "v0.1.14",
+    tag:      "v0.1.14",
     revision: "3d5e5c3b3e844d4a25d16d7a1d9dfffcfa0fb14b"
   license "Apache-2.0"
   head "https://github.com/viamrobotics/slam.git", branch: "main"
 
-  depends_on "pkg-config" => :build
-  depends_on "go" => :build
   depends_on "cmake" => :build
-  depends_on "grpc"
-  depends_on "glew"
-  depends_on "opencv@4"
-  depends_on "eigen"
+  depends_on "go" => :build
+  depends_on "pkg-config" => :build
   depends_on "boost"
+  depends_on "eigen"
+  depends_on "glew"
+  depends_on "grpc"
+  depends_on "opencv@4"
   depends_on "openssl"
   depends_on "pangolin"
 
@@ -23,11 +23,16 @@ class OrbGrpcServer < Formula
       system "make", "buf"
       system "make", "buildorb"
       if OS.mac?
-        system "install_name_tool", "-change", buildpath.to_s.delete_prefix("/private") + "/slam-libraries/viam-orb-slam3/ORB_SLAM3/Thirdparty/DBoW2/lib/libDBoW2.dylib", "#{lib}/libDBoW2.dylib", "viam-orb-slam3/ORB_SLAM3/lib/libORB_SLAM3.dylib"
-        system "install_name_tool", "-change", buildpath.to_s.delete_prefix("/private") + "/slam-libraries/viam-orb-slam3/ORB_SLAM3/Thirdparty/g2o/lib/libg2o.dylib", "#{lib}/libg2o.dylib", "viam-orb-slam3/ORB_SLAM3/lib/libORB_SLAM3.dylib"
-        system "install_name_tool", "-change", buildpath.to_s.delete_prefix("/private") + "/slam-libraries/viam-orb-slam3/ORB_SLAM3/Thirdparty/DBoW2/lib/libDBoW2.dylib", "#{lib}/libDBoW2.dylib", "viam-orb-slam3/bin/orb_grpc_server"
-        system "install_name_tool", "-change", buildpath.to_s.delete_prefix("/private") + "/slam-libraries/viam-orb-slam3/ORB_SLAM3/Thirdparty/g2o/lib/libg2o.dylib", "#{lib}/libg2o.dylib", "viam-orb-slam3/bin/orb_grpc_server"
-        system "install_name_tool", "-change", buildpath.to_s.delete_prefix("/private") + "/slam-libraries/viam-orb-slam3/ORB_SLAM3/lib/libORB_SLAM3.dylib", "#{lib}/libORB_SLAM3.dylib", "viam-orb-slam3/bin/orb_grpc_server"
+        system "install_name_tool", "-change",
+buildpath.to_s.delete_prefix("/private") + "/slam-libraries/viam-orb-slam3/ORB_SLAM3/Thirdparty/DBoW2/lib/libDBoW2.dylib", "#{lib}/libDBoW2.dylib", "viam-orb-slam3/ORB_SLAM3/lib/libORB_SLAM3.dylib"
+        system "install_name_tool", "-change",
+buildpath.to_s.delete_prefix("/private") + "/slam-libraries/viam-orb-slam3/ORB_SLAM3/Thirdparty/g2o/lib/libg2o.dylib", "#{lib}/libg2o.dylib", "viam-orb-slam3/ORB_SLAM3/lib/libORB_SLAM3.dylib"
+        system "install_name_tool", "-change",
+buildpath.to_s.delete_prefix("/private") + "/slam-libraries/viam-orb-slam3/ORB_SLAM3/Thirdparty/DBoW2/lib/libDBoW2.dylib", "#{lib}/libDBoW2.dylib", "viam-orb-slam3/bin/orb_grpc_server"
+        system "install_name_tool", "-change",
+buildpath.to_s.delete_prefix("/private") + "/slam-libraries/viam-orb-slam3/ORB_SLAM3/Thirdparty/g2o/lib/libg2o.dylib", "#{lib}/libg2o.dylib", "viam-orb-slam3/bin/orb_grpc_server"
+        system "install_name_tool", "-change",
+buildpath.to_s.delete_prefix("/private") + "/slam-libraries/viam-orb-slam3/ORB_SLAM3/lib/libORB_SLAM3.dylib", "#{lib}/libORB_SLAM3.dylib", "viam-orb-slam3/bin/orb_grpc_server"
       end
       bin.install "viam-orb-slam3/bin/orb_grpc_server"
       lib.install Dir["viam-orb-slam3/ORB_SLAM3/lib/*"]

--- a/Formula/tensorflowlite.rb
+++ b/Formula/tensorflowlite.rb
@@ -25,5 +25,4 @@ class Tensorflowlite < Formula
     include.install "tensorflow/lite/c/c_api_types.h" => "tensorflow/lite/c/c_api_types.h"
     include.install "tensorflow/lite/c/common.h" => "tensorflow/lite/c/common.h"
   end
-
 end

--- a/Formula/viam-server.rb
+++ b/Formula/viam-server.rb
@@ -1,8 +1,8 @@
 class ViamServer < Formula
   desc "The main server application of the viam robot development kit (RDK)"
   homepage "https://www.viam.com/"
-  url "https://github.com/viamrobotics/rdk/archive/refs/tags/v0.2.8.tar.gz"
-  sha256 "0fe1087fd674d58a71892004e35973bb71803e1d26cef601b1bab6873a7db067"
+  url "https://github.com/viamrobotics/rdk/archive/refs/tags/v0.2.10.tar.gz"
+  sha256 "55dd954b1e69cdd84082d7fc7554e962dfdde275d0e8c7caf856518d41035948"
   license "AGPL-3.0"
   head "https://github.com/viamrobotics/rdk.git", branch: "main"
 

--- a/Formula/viam-server.rb
+++ b/Formula/viam-server.rb
@@ -1,5 +1,5 @@
 class ViamServer < Formula
-  desc "The main server application of the viam robot development kit (RDK)"
+  desc "Main server application of the viam robot development kit (RDK)"
   homepage "https://www.viam.com/"
   url "https://github.com/viamrobotics/rdk/archive/refs/tags/v0.2.10.tar.gz"
   sha256 "55dd954b1e69cdd84082d7fc7554e962dfdde275d0e8c7caf856518d41035948"
@@ -7,15 +7,15 @@ class ViamServer < Formula
   head "https://github.com/viamrobotics/rdk.git", branch: "main"
 
   depends_on "go" => :build
-  depends_on "nlopt"
-  depends_on "x264"
-  depends_on "opus"
-  depends_on "tensorflowlite" 
   depends_on "ffmpeg"
+  depends_on "nlopt"
+  depends_on "opus"
+  depends_on "tensorflowlite"
+  depends_on "x264"
 
   def install
     with_env(
-      "TAG_VERSION" => "v#{version.to_s}"
+      "TAG_VERSION" => "v#{version}",
     ) do
       system "make", "server"
     end

--- a/Formula/viam-server.rb
+++ b/Formula/viam-server.rb
@@ -1,8 +1,8 @@
 class ViamServer < Formula
   desc "The main server application of the viam robot development kit (RDK)"
   homepage "https://www.viam.com/"
-  url "https://github.com/viamrobotics/rdk/archive/refs/tags/v0.2.9.tar.gz"
-  sha256 "3d989f4dbd63736c509463ec12c4455b4640bdf1ed53469922e23ccecf76df4a"
+  url "https://github.com/viamrobotics/rdk/archive/refs/tags/v0.2.8.tar.gz"
+  sha256 "0fe1087fd674d58a71892004e35973bb71803e1d26cef601b1bab6873a7db067"
   license "AGPL-3.0"
   head "https://github.com/viamrobotics/rdk.git", branch: "main"
 

--- a/bump-version.sh
+++ b/bump-version.sh
@@ -17,8 +17,6 @@ then
 	exit 0
 fi
 
-pwd
-ls -l
 git status
 
 brew bump-formula-pr --write-only --version $NEW_VERSION $FORMULA

--- a/bump-version.sh
+++ b/bump-version.sh
@@ -17,4 +17,8 @@ then
 	exit 0
 fi
 
+pwd
+ls -l
+git status
+
 brew bump-formula-pr --write-only --version $NEW_VERSION $FORMULA

--- a/bump-version.sh
+++ b/bump-version.sh
@@ -17,6 +17,4 @@ then
 	exit 0
 fi
 
-git status
-
 brew bump-formula-pr --write-only --version $NEW_VERSION $FORMULA

--- a/bump-version.sh
+++ b/bump-version.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -x
+
+FORMULA=$1
+
+if [ -z $FORMULA ]
+then
+	echo "Formula name missing or invalid"
+	exit 1
+fi
+
+CHECK=$(brew bump $FORMULA)
+CUR_VERSION=$(echo "$CHECK" | grep Current | awk '{print $4}')
+NEW_VERSION=$(echo "$CHECK" | grep livecheck | awk '{print $4}')
+
+if [ $CUR_VERSION = $NEW_VERSION ]
+then
+	exit 0
+fi
+
+brew bump-formula-pr --write-only --version $NEW_VERSION $FORMULA

--- a/bump-version.sh
+++ b/bump-version.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash
 
 FORMULA=$1
 


### PR DESCRIPTION
This should handle automatically bumping homebrew versions. To keep things simple, it just runs once an hour and polls for updates from the various repos (currently viam-server, carto-grpc-server, and orb-grpc-server) and looks for new versions. Zero integration should be needed on the other end.

The extra changes are because I ran "brew audit" against the formulae as well, so the changes actually in the formula themselves is just basically linting.

Lastly, as this is a completely public repo, with zero secrets or other integration and isn't needing even a custom docker image, I'm letting this run on a github runner.