### PR TITLE
RSDK-2024 - Add an orbslam3 module brew package

### DIFF
--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -44,6 +44,9 @@ jobs:
     - name: Bump orb-grpc-server
       run: ./bump-version.sh orb-grpc-server
 
+    - name: Bump orb-slam3-module
+      run: ./bump-version.sh orb-slam3-module
+
     - name: Commit changes
       uses: stefanzweifel/git-auto-commit-action@v4
       with:

--- a/Formula/orb-grpc-server.rb
+++ b/Formula/orb-grpc-server.rb
@@ -7,7 +7,7 @@ class OrbGrpcServer < Formula
   license "Apache-2.0"
   head "https://github.com/viamrobotics/viam-orb-slam3.git", branch: "main"
 
-  conflicts_with "orb-slam3-module", because: "orb-slam3-module does also install orb_grpc_server"
+  conflicts_with "orb-slam3-module", because: "orb-slam3-module also installs orb_grpc_server"
 
   depends_on "cmake" => :build
   depends_on "go" => :build

--- a/Formula/orb-grpc-server.rb
+++ b/Formula/orb-grpc-server.rb
@@ -7,6 +7,8 @@ class OrbGrpcServer < Formula
   license "Apache-2.0"
   head "https://github.com/viamrobotics/viam-orb-slam3.git", branch: "main"
 
+  conflicts_with "orb-slam3-module", because: "orb-slam3-module does also install orb_grpc_server"
+
   depends_on "cmake" => :build
   depends_on "go" => :build
   depends_on "pkg-config" => :build

--- a/Formula/orb-slam3-module.rb
+++ b/Formula/orb-slam3-module.rb
@@ -1,0 +1,44 @@
+class OrbSlam3Module < Formula
+  desc "Viam slam GRPC server for ORB_SLAM3"
+  homepage "https://www.viam.com/"
+  url "https://github.com/viamrobotics/viam-orb-slam3.git",
+    tag:      "v0.3.1",
+    revision: "3726e0f9e8f05402406eeb81d52d39dcbf432b53"
+  license "Apache-2.0"
+  head "https://github.com/viamrobotics/viam-orb-slam3.git", branch: "main"
+
+  depends_on "cmake" => :build
+  depends_on "go" => :build
+  depends_on "pkg-config" => :build
+  depends_on "boost"
+  depends_on "eigen"
+  depends_on "glew"
+  depends_on "grpc"
+  depends_on "opencv@4"
+  depends_on "openssl"
+  depends_on "pangolin"
+
+  def install
+    system "make", "buf"
+    system "make", "build"
+    if OS.mac?
+      system "install_name_tool", "-change",
+buildpath.to_s.delete_prefix("/private") + "/viam-orb-slam3/ORB_SLAM3/Thirdparty/DBoW2/lib/libDBoW2.dylib", "#{lib}/libDBoW2.dylib", "viam-orb-slam3/ORB_SLAM3/lib/libORB_SLAM3.dylib"
+      system "install_name_tool", "-change",
+buildpath.to_s.delete_prefix("/private") + "/viam-orb-slam3/ORB_SLAM3/Thirdparty/g2o/lib/libg2o.dylib", "#{lib}/libg2o.dylib", "viam-orb-slam3/ORB_SLAM3/lib/libORB_SLAM3.dylib"
+      system "install_name_tool", "-change",
+buildpath.to_s.delete_prefix("/private") + "/viam-orb-slam3/ORB_SLAM3/Thirdparty/DBoW2/lib/libDBoW2.dylib", "#{lib}/libDBoW2.dylib", "viam-orb-slam3/bin/orb_grpc_server"
+      system "install_name_tool", "-change",
+buildpath.to_s.delete_prefix("/private") + "/viam-orb-slam3/ORB_SLAM3/Thirdparty/g2o/lib/libg2o.dylib", "#{lib}/libg2o.dylib", "viam-orb-slam3/bin/orb_grpc_server"
+      system "install_name_tool", "-change",
+buildpath.to_s.delete_prefix("/private") + "/viam-orb-slam3/ORB_SLAM3/lib/libORB_SLAM3.dylib", "#{lib}/libORB_SLAM3.dylib", "viam-orb-slam3/bin/orb_grpc_server"
+    end
+    bin.install "bin/orb-slam3-module"
+    bin.install "viam-orb-slam3/bin/orb_grpc_server"
+    lib.install Dir["viam-orb-slam3/ORB_SLAM3/lib/*"]
+    lib.install Dir["viam-orb-slam3/ORB_SLAM3/Thirdparty/DBoW2/lib/*"]
+    lib.install Dir["viam-orb-slam3/ORB_SLAM3/Thirdparty/g2o/lib/*"]
+    (share/"orbslam/Vocabulary").mkpath
+    share.install "viam-orb-slam3/ORB_SLAM3/Vocabulary/ORBvoc.txt" => "orbslam/Vocabulary/ORBvoc.txt"
+  end
+end

--- a/Formula/orb-slam3-module.rb
+++ b/Formula/orb-slam3-module.rb
@@ -1,5 +1,5 @@
 class OrbSlam3Module < Formula
-  desc "Viam slam GRPC server for ORB_SLAM3"
+  desc "Viam ORB_SLAM3 modular service"
   homepage "https://www.viam.com/"
   url "https://github.com/viamrobotics/viam-orb-slam3.git",
     tag:      "v0.3.1",

--- a/Formula/orb-slam3-module.rb
+++ b/Formula/orb-slam3-module.rb
@@ -7,6 +7,8 @@ class OrbSlam3Module < Formula
   license "Apache-2.0"
   head "https://github.com/viamrobotics/viam-orb-slam3.git", branch: "main"
 
+  conflicts_with "orb-grpc-server", because: "orb-grpc-server does also install orb_grpc_server"
+
   depends_on "cmake" => :build
   depends_on "go" => :build
   depends_on "pkg-config" => :build

--- a/Formula/orb-slam3-module.rb
+++ b/Formula/orb-slam3-module.rb
@@ -7,7 +7,7 @@ class OrbSlam3Module < Formula
   license "Apache-2.0"
   head "https://github.com/viamrobotics/viam-orb-slam3.git", branch: "main"
 
-  conflicts_with "orb-grpc-server", because: "orb-grpc-server does also install orb_grpc_server"
+  conflicts_with "orb-grpc-server", because: "orb-grpc-server also installs orb_grpc_server"
 
   depends_on "cmake" => :build
   depends_on "go" => :build


### PR DESCRIPTION
Ticket: https://viam.atlassian.net/browse/RSDK-2024

**Done:** Add the orb-slam3-module brew package

**Note:** The added file is identical to orb-grpc-server.rb except for two lines that I've highlighted.

**Tested on:** MacOS x86_64 (installed only since it does not function properly on macOS)