### PR TITLE
RSDK-2860 - Fix cartographer missing dependencies

### DIFF
--- a/Formula/cartographer-module.rb
+++ b/Formula/cartographer-module.rb
@@ -10,9 +10,14 @@ class CartographerModule < Formula
   depends_on "cmake" => :build
   depends_on "go" => :build
   depends_on "ninja" => :build
+  depends_on "pkg-config" => :build
   depends_on "protobuf"
   depends_on "grpc"
+  depends_on "googletest"
+  depends_on "ceres-solver"
   depends_on "pcl"
+  depends_on "lua@5.3"
+  depends_on "cairo"
 
   def install
     system "make", "buf"


### PR DESCRIPTION
Ticket: https://viam.atlassian.net/browse/RSDK-2860

Problem:
* `brew install cartographer-module` failed to build on an arm64 Mac.

Solution:
* I ran `brew remove --force $(brew list)` to uninstall all libraries
* I added missing dependencies until the brew package was installed successfully.

Tested on:
* Mac x86_64