### PR TITLE
RSDK-2862 Do not update brew formula on new rc versions

### DIFF
--- a/bump-version.sh
+++ b/bump-version.sh
@@ -19,4 +19,10 @@ then
 	exit 0
 fi
 
+# Do not update brew formulas for rc (release candidate) versions.
+if [[ $NEW_VERSION =~ [0-9]+.[0-9]+.[0-9]+-rc[0-9]+ ]]
+then
+	exit 0
+fi
+
 brew bump-formula-pr --write-only --version $NEW_VERSION $FORMULA


### PR DESCRIPTION
Our new release process involves tagging both rc and stable commits on a release branch rather than the main branch.

It seems `brew bump` will already not pick up a commit tagged as an rc (e.g., v1.2.3-rc0) as a new version:

I added a tag *v0.3.11-rc0* in viam-cartographer that is semantically greater than [all](https://github.com/viamrobotics/viam-cartographer/tags) earlier tags (note, the tags don't show up in order), and `brew bump cartographer-module` didn't see it:

```
% brew bump cartographer-module
==> cartographer-module
Current formula version:  0.3.7
Latest livecheck version: 0.3.10
Latest Repology version:  not found
Open pull requests:       none
Closed pull requests:     none
```

I then added a tag *v0.3.11* (even without checking "Set as latest release") and `brew bump cartographer-module` did see it:

```
% brew bump cartographer-module
==> cartographer-module
Current formula version:  0.3.7
Latest livecheck version: 0.3.11
Latest Repology version:  not found
Open pull requests:       none
Closed pull requests:     none
```

Still, we could add the change in this PR as an additional safety measure.