### PR TITLE
RSDK-2995 - Add missing rplidar dependency (jpeg)

### DIFF
--- a/Formula/rplidar-module.rb
+++ b/Formula/rplidar-module.rb
@@ -9,6 +9,7 @@ class RplidarModule < Formula
 
   depends_on "go" => :build
   depends_on "swig" => :build
+  depends_on "jpeg"
 
   def install
     system "make", "build-module"


### PR DESCRIPTION
Ticket: https://viam.atlassian.net/browse/RSDK-2995

Problem:
* `brew install rplidar-module` failed to build on an x86_64 Mac.

Solution:
* I ran `brew remove --force $(brew list)` to uninstall all libraries
* I added missing dependencies until the brew package was installed successfully.

Tested on:
* Mac x86_64