### PR TITLE
add-nlopt-static-to-carto

### DIFF
--- a/Formula/cartographer-module.rb
+++ b/Formula/cartographer-module.rb
@@ -18,6 +18,7 @@ class CartographerModule < Formula
   depends_on "pcl"
   depends_on "lua@5.3"
   depends_on "cairo"
+  depends_on "nlopt-static"
 
   def install
     system "make", "buf"


### PR DESCRIPTION
Manually tested on mac:

```
➜  ~ brew remove --force $(brew list)
... brew removal output
➜  ~ cd homebrew-brews
➜  homebrew-brews git:(main) ✗ ls
Formula         LICENSE         README.md       bump-version.sh logs
➜  homebrew-brews git:(main) ✗ cd Formula
➜  Formula git:(main) ✗ brew reinstall --build-from-source ./cartographer-module.rb
```

NOTE: We will need to remove publishing carto_grpc_server after latest cartographer-module is promoted to stable