### PR TITLE
RSDK-4706 add viam.rb formula for cli

### DIFF
--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -50,8 +50,8 @@ jobs:
     - name: Bump viam-dialdbg
       run: ./bump-version.sh viam-dialdbg
 
-    - name: Bump viam-cli
-      run: ./bump-version.sh viam-cli
+    - name: Bump viam
+      run: ./bump-version.sh viam
 
     - name: Commit changes
       uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -50,6 +50,9 @@ jobs:
     - name: Bump viam-dialdbg
       run: ./bump-version.sh viam-dialdbg
 
+    - name: Bump viam-cli
+      run: ./bump-version.sh viam-cli
+
     - name: Commit changes
       uses: stefanzweifel/git-auto-commit-action@v4
       with:

--- a/Formula/viam-cli.rb
+++ b/Formula/viam-cli.rb
@@ -1,6 +1,7 @@
 class ViamCli < Formula
-  version = "v0.8.0"
-  url "https://github.com/viamrobotics/rdk/archive/refs/tags/#{version}.tar.gz"
+  url "https://github.com/viamrobotics/rdk/archive/refs/tags/v0.8.0.tar.gz"
+  sha256 "ec8f0f5a4dda80de5e36e3241a219c0d7e98225754ae0c994dbcd2e4b2d32dd5"
+  head "https://github.com/viamrobotics/rdk.git", branch: "main"
 
   depends_on "go" => :build
 

--- a/Formula/viam-cli.rb
+++ b/Formula/viam-cli.rb
@@ -1,0 +1,17 @@
+class ViamCli < Formula
+  arch = Hardware::CPU.intel? ? "amd64" : "arm64"
+  version = "0.8.0"
+  os_name = OS.linux? ? "linux" : "darwin"
+  platform = "#{os_name}-#{arch}"
+  desc "CLI for admin tasks in your Viam account"
+  homepage "https://docs.viam.com/manage/cli/"
+  shas = {
+    "linux-amd64" => "5d4759f18ed4772dadf72aa318b503bfb7e2f963ed9553ce7d4cea45c0caed93"
+  }
+  sha256 shas[platform]
+  url "https://storage.googleapis.com/packages.viam.com/apps/viam-cli/viam-cli-v#{version}-#{platform}"
+
+  def install
+    bin.install "packages.viam.com" => "viam"
+  end
+end

--- a/Formula/viam-cli.rb
+++ b/Formula/viam-cli.rb
@@ -1,17 +1,12 @@
 class ViamCli < Formula
-  arch = Hardware::CPU.intel? ? "amd64" : "arm64"
-  version = "0.8.0"
-  os_name = OS.linux? ? "linux" : "darwin"
-  platform = "#{os_name}-#{arch}"
-  desc "CLI for admin tasks in your Viam account"
-  homepage "https://docs.viam.com/manage/cli/"
-  shas = {
-    "linux-amd64" => "5d4759f18ed4772dadf72aa318b503bfb7e2f963ed9553ce7d4cea45c0caed93"
-  }
-  sha256 shas[platform]
-  url "https://storage.googleapis.com/packages.viam.com/apps/viam-cli/viam-cli-v#{version}-#{platform}"
+  version = "v0.8.0"
+  url "https://github.com/viamrobotics/rdk/archive/refs/tags/#{version}.tar.gz"
+
+  depends_on "go" => :build
 
   def install
-    bin.install "packages.viam.com" => "viam"
+    ENV["TAG_VERSION"] = version
+    system("make", "cli-ci")
+    bin.install Dir["bin/*/viam-cli"][0] => "viam"
   end
 end

--- a/Formula/viam.rb
+++ b/Formula/viam.rb
@@ -2,7 +2,7 @@ class Viam < Formula
   url "https://github.com/viamrobotics/rdk/archive/refs/tags/v0.8.0.tar.gz"
   sha256 "ec8f0f5a4dda80de5e36e3241a219c0d7e98225754ae0c994dbcd2e4b2d32dd5"
   head "https://github.com/viamrobotics/rdk.git", branch: "main"
-  desc "Viam CLI for managing your modules and auth keys. (See also: viam-server for running a robot)."
+  desc "Viam CLI for managing robots, modules, orgs, etc. on the Viam platform. (See also: viam-server for running a robot)."
 
   depends_on "go" => :build
 

--- a/Formula/viam.rb
+++ b/Formula/viam.rb
@@ -1,7 +1,8 @@
-class ViamCli < Formula
+class Viam < Formula
   url "https://github.com/viamrobotics/rdk/archive/refs/tags/v0.8.0.tar.gz"
   sha256 "ec8f0f5a4dda80de5e36e3241a219c0d7e98225754ae0c994dbcd2e4b2d32dd5"
   head "https://github.com/viamrobotics/rdk.git", branch: "main"
+  desc "Viam CLI for managing your modules and auth keys. (See also: viam-server for running a robot)."
 
   depends_on "go" => :build
 


### PR DESCRIPTION
## What changed
- add viam-cli to support `brew install viam`
## Follow-up work
- recent brew supports [tap+bottle](https://brew.sh/2020/11/18/homebrew-tap-with-bottles-uploaded-to-github-releases/). We should look into this so we can ship binaries to shrink download + speed up install for new users