### PR TITLE
hotfix viam.rb 0.8.1a

### DIFF
--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -50,9 +50,6 @@ jobs:
     - name: Bump viam-dialdbg
       run: ./bump-version.sh viam-dialdbg
 
-    - name: Bump viam
-      run: ./bump-version.sh viam
-
     - name: Commit changes
       uses: stefanzweifel/git-auto-commit-action@v4
       with:

--- a/Formula/viam.rb
+++ b/Formula/viam.rb
@@ -1,13 +1,13 @@
 class Viam < Formula
-  url "https://github.com/viamrobotics/rdk/archive/refs/tags/v0.8.1.tar.gz"
-  sha256 "7d07ddbf51e5fbe855c1b3d5564ef7a1d8fc18519f7917e6f889e11cf8a37206"
+  url "https://github.com/viamrobotics/rdk/archive/f4fe50894438be446d1734a6c86787d36da1e632.tar.gz"
+  sha256 "fbed9f6e2b1bddf1ff435a12d142e07cf6ce55d6f20d73103c217c171daf2599"
   head "https://github.com/viamrobotics/rdk.git", branch: "main"
   desc "Viam CLI for managing robots, modules, orgs, etc. on the Viam platform. (See also: viam-server for running a robot)."
 
   depends_on "go" => :build
 
   def install
-    ENV["TAG_VERSION"] = version
+    ENV["TAG_VERSION"] = "0.8.1a"
     system("make", "cli-ci")
     bin.install Dir["bin/*/viam-cli"][0] => "viam"
   end

--- a/Formula/viam.rb
+++ b/Formula/viam.rb
@@ -3,11 +3,12 @@ class Viam < Formula
   sha256 "fbed9f6e2b1bddf1ff435a12d142e07cf6ce55d6f20d73103c217c171daf2599"
   head "https://github.com/viamrobotics/rdk.git", branch: "main"
   desc "Viam CLI for managing robots, modules, orgs, etc. on the Viam platform. (See also: viam-server for running a robot)."
+  version "0.8.1a"
 
   depends_on "go" => :build
 
   def install
-    ENV["TAG_VERSION"] = "0.8.1a"
+    ENV["TAG_VERSION"] = version
     system("make", "cli-ci")
     bin.install Dir["bin/*/viam-cli"][0] => "viam"
   end


### PR DESCRIPTION
- pin viam.rb to latest rdk commit to get auth fixes
- label this 0.8.1a
- remove viam.rb from bump-versions.yml temporarily