### PR TITLE
Add caveat about rust dependency for viam-dialdbg

### DIFF
--- a/Formula/viam-dialdbg.rb
+++ b/Formula/viam-dialdbg.rb
@@ -13,4 +13,12 @@ class ViamDialdbg < Formula
     system "make", "build-dialdbg"
     bin.install "target/release/viam-dialdbg"
   end
+
+  def caveats
+    <<~EOS
+      viam-dialdbg may have installed Rust as a dependency via brew. If you
+      manage your own Rust installations (via rustup, etc.), you can run `brew
+      remove rust` or `brew unlink rust` after installing.
+    EOS
+  end
 end


### PR DESCRIPTION
`brew install viam-dialdbg` will `brew install rust` as a dependency. Adds a caveat to the brew formula that Rust may have been installed and users can either remove it or unlink it if they manage their Rust installations with something like `rustup`.