### PR TITLE
add pinned suite-sparse, depend on pinned suite-sparse in ceres

### DIFF
--- a/Formula/ceres-solver@2.1.rb
+++ b/Formula/ceres-solver@2.1.rb
@@ -17,10 +17,16 @@ class CeresSolverAT21 < Formula
   depends_on "glog"
   depends_on "metis"
   depends_on "openblas"
-  depends_on "suite-sparse"
+  depends_on "suite-sparse@7.1"
   depends_on "tbb"
 
   fails_with gcc: "5" # C++17
+
+  # Fix version detection for suite-sparse >= 6.0. Remove in next release.
+  patch do
+    url "https://github.com/ceres-solver/ceres-solver/commit/352b320ab1b5438a0838aea09cbbf07fa4ff5d71.patch?full_index=1"
+    sha256 "0289adbea4cb66ccff57eeb844dd6d6736c37649b6ff329fed73cf0e9461fb53"
+  end
 
   def install
     system "cmake", "-S", ".", "-B", "homebrew-build",

--- a/Formula/suite-sparse@7.1.rb
+++ b/Formula/suite-sparse@7.1.rb
@@ -1,0 +1,59 @@
+class SuiteSparseAT71 < Formula
+  desc "Suite of Sparse Matrix Software"
+  homepage "https://people.engr.tamu.edu/davis/suitesparse.html"
+  url "https://github.com/DrTimothyAldenDavis/SuiteSparse/archive/refs/tags/v7.1.0.tar.gz"
+  sha256 "4cd3d161f9aa4f98ec5fa725ee5dc27bca960a3714a707a7d12b3d0abb504679"
+  license all_of: [
+    "BSD-3-Clause",
+    "LGPL-2.1-or-later",
+    "GPL-2.0-or-later",
+    "Apache-2.0",
+    "GPL-3.0-only",
+    any_of: ["LGPL-3.0-or-later", "GPL-2.0-or-later"],
+  ]
+
+  livecheck do
+    skip "intentionally held back"
+  end
+
+  depends_on "cmake" => :build
+  depends_on "metis"
+  depends_on "openblas"
+
+  uses_from_macos "m4"
+
+  conflicts_with "mongoose", because: "suite-sparse vendors libmongoose.dylib"
+
+  def install
+    # Force cmake to use our compiler shims
+    if OS.mac?
+      inreplace "GraphBLAS/cmake_modules/GraphBLAS_JIT_configure.cmake",
+          "GB_C_COMPILER  \"${CMAKE_C_COMPILER}\"", "GB_C_COMPILER \"#{ENV.cc}\""
+    end
+
+    cmake_args = *std_cmake_args, "-DCMAKE_INSTALL_RPATH=#{rpath}"
+    args = [
+      "INSTALL=#{prefix}",
+      "BLAS=-L#{Formula["openblas"].opt_lib} -lopenblas",
+      "LAPACK=$(BLAS)",
+      "MY_METIS_LIB=-L#{Formula["metis"].opt_lib} -lmetis",
+      "MY_METIS_INC=#{Formula["metis"].opt_include}",
+      "CMAKE_OPTIONS=#{cmake_args.join(" ")}",
+      "JOBS=#{ENV.make_jobs}",
+    ]
+
+    # Parallelism is managed through the `JOBS` make variable and not with `-j`.
+    ENV.deparallelize
+    system "make", "library", *args
+    system "make", "install", *args
+    lib.install Dir["**/*.a"]
+    pkgshare.install "KLU/Demo/klu_simple.c"
+  end
+
+  test do
+    system ENV.cc, "-o", "test", pkgshare/"klu_simple.c",
+           "-L#{lib}", "-lsuitesparseconfig", "-lklu"
+    assert_predicate testpath/"test", :exist?
+    assert_match "x [0] = 1", shell_output("./test")
+  end
+end


### PR DESCRIPTION
## What
- add pinned suite-parse 7.1.0
- consume it in our pinned ceres
## Why
- cartographer requests Ceres with SuiteParse component in its CMakeLists [here](https://github.com/cartographer-project/cartographer/blob/master/CMakeLists.txt#L39)
- before, I was unintentionally flagging off SuiteParse by removing a patch Ceres to do for version parsing
- current brew suite-sparse (7.3.0) changed an int to a long or something which breaks the build