### PR TITLE
RSDK-6583 Fix brew install cartographer-module

### DIFF
--- a/Formula/cartographer-module.rb
+++ b/Formula/cartographer-module.rb
@@ -12,16 +12,18 @@ class CartographerModule < Formula
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
   depends_on "cairo"
-  depends_on "ceres-solver"
+  depends_on "viamrobotics/brews/suite-sparse@7.1"
+  depends_on "viamrobotics/brews/ceres-solver@2.1"
   depends_on "googletest"
   depends_on "grpc"
   depends_on "lua@5.3"
-  depends_on "nlopt-static"
+  depends_on "viamrobotics/brews/nlopt-static"
   depends_on "pcl"
-  depends_on "protobuf@21"
+  depends_on "protobuf"
 
   def install
-    system "make", "buf"
+    system "env"
+    ENV["CGO_LDFLAGS"] = " -labsl_log_internal_message -labsl_log_internal_check_op"
     system "make", "build"
 
     if OS.linux?

--- a/Formula/cartographer-module.rb
+++ b/Formula/cartographer-module.rb
@@ -22,7 +22,9 @@ class CartographerModule < Formula
   depends_on "protobuf"
 
   def install
-    ENV["CGO_LDFLAGS"] = " -labsl_log_internal_message -labsl_log_internal_check_op"
+    if OS.mac?
+      ENV["CGO_LDFLAGS"] = " -labsl_log_internal_message -labsl_log_internal_check_op"
+    end
     system "make", "build"
 
     if OS.linux?

--- a/Formula/cartographer-module.rb
+++ b/Formula/cartographer-module.rb
@@ -22,7 +22,6 @@ class CartographerModule < Formula
   depends_on "protobuf"
 
   def install
-    system "env"
     ENV["CGO_LDFLAGS"] = " -labsl_log_internal_message -labsl_log_internal_check_op"
     system "make", "build"
 


### PR DESCRIPTION
This PR fixing the ongoing brew issue. The main issue was that Xcode was out of date (14 instead of 15.1) due to the reference being tied to Xcode which in turn required an OS update. 

The solution was to ensure that the environmental command lien tool path was linked to the independent install located at `/Library/Developer/CommandLineTools`. This can be confirmed on your system by running:

`xcode-select -p`

and updated with:

`xcode-select --switch /Library/Developer/CommandLineTools`

**JIRA Ticket:** https://viam.atlassian.net/browse/RSDK-6583