### PR TITLE
RSDK-8551 - update cli dependencies

### DIFF
--- a/Formula/viam.rb
+++ b/Formula/viam.rb
@@ -6,6 +6,8 @@ class Viam < Formula
   head "https://github.com/viamrobotics/rdk.git", branch: "main"
 
   depends_on "go" => :build
+  depends_on "python3"
+  depends_on "pip3"
 
   def install
     ENV["TAG_VERSION"] = version


### PR DESCRIPTION
Update dependencies for CLI to include `python` and `pip`. These are necessary as part of [RDK#4315](https://github.com/viamrobotics/rdk/pull/4315).

edit: putting this into draft while I do some refactoring of the RDK#4315 work, which may remove the need for this.