### PR TITLE
use root-url in bottle command

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,11 +29,13 @@ jobs:
         env:
             HOMEBREW_GITHUB_PACKAGES_USER: ${{ github.repository_owner }}
             HOMEBREW_GITHUB_PACKAGES_TOKEN: ${{ github.token }}
+            # if you don't override root-url it will upload to / download from the wrong place
+            ROOT_URL: https://ghcr.io/v2/${{ github.repository }}
         run: |
           brew tap viamrobotics/brews
           brew install --build-bottle viam
-          brew bottle --json viam
-          brew pr-upload --root-url https://ghcr.io/v2/${{ github.repository }}
+          brew bottle --json --root-url $ROOT_URL viam
+          brew pr-upload --root-url $ROOT_URL
 
       - name: push changes
         run: |

--- a/Formula/viam.rb
+++ b/Formula/viam.rb
@@ -5,6 +5,12 @@ class Viam < Formula
   sha256 "efbe2508d7642aca7f6d3a3be2d24184e83a3fb98ba159462d4a415734a14cb9"
   head "https://github.com/viamrobotics/rdk.git", branch: "main"
 
+  bottle do
+    root_url "https://ghcr.io/v2/viamrobotics/brews"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, x86_64_linux: "e02baaca1ae314529251d8c360a2a659fc05896ce1fb69dee47ec88da2f3ee82"
+  end
+
   depends_on "go" => :build
 
   def install


### PR DESCRIPTION
## What changed
- pass root-url to `brew bottle` command (not just to `brew pr-upload`)
## Why
`bottle` affects download location, `pr-upload` affects upload, both are necessary, nothing is checking that they agree. previous version led to `brew install` attempting to download from homebrew/core on linux