### PR TITLE
trigger bottle.yml script from bump-version

### DIFF
--- a/.github/workflows/bottle.yml
+++ b/.github/workflows/bottle.yml
@@ -1,15 +1,25 @@
-name: brew pr-pull
+name: brew bottle
 
 on:
+  workflow_call:
+    inputs:
+      formula:
+        type: string
+        default: viam
+        description: which formula to bottle
   workflow_dispatch:
     inputs:
-      runner:
-        default: ubuntu-22.04
-        description: passed down to runs-on
+      formula:
+        type: string
+        default: viam
+        description: which formula to bottle
 
 jobs:
-  pr-pull:
-    runs-on: ${{ inputs.runner }}
+  bottle:
+    strategy:
+      matrix:
+        runs-on: [ubuntu-22.04]
+    runs-on: ${{ matrix.runs-on }}
     permissions:
       contents: write
       packages: write
@@ -33,8 +43,8 @@ jobs:
             ROOT_URL: https://ghcr.io/v2/${{ github.repository }}
         run: |
           brew tap viamrobotics/brews
-          brew install --build-bottle viam
-          brew bottle --json --root-url $ROOT_URL viam
+          brew install --build-bottle ${{ inputs.formula }}
+          brew bottle --json --root-url $ROOT_URL ${{ inputs.formula }}
           brew pr-upload --root-url $ROOT_URL
 
       - name: push changes

--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -17,6 +17,8 @@ jobs:
       image: homebrew/brew
       options: --user root
     timeout-minutes: 10
+    outputs:
+      bump-viam: ${{ steps.viam.outputs.bump }}
     steps:
     - name: Check out code
       uses: actions/checkout@v3
@@ -54,9 +56,19 @@ jobs:
       run: ./bump-version.sh viam-cpp-sdk
 
     - name: Bump viam
-      run: ./bump-version.sh viam
+      id: viam
+      run: |
+        echo bump=$(./needs-bump.sh) >> "$GITHUB_OUTPUT"
+        ./bump-version.sh viam
 
     - name: Commit changes
       uses: stefanzweifel/git-auto-commit-action@v4
       with:
         commit_message: Auto-update of package versions
+
+  bottle-viam:
+    needs: bump-versions
+    if: needs.bump-versions.outputs.bump-viam == 'true'
+    uses: ./.github/workflows/bottle.yml
+    with:
+      formula: viam

--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -19,6 +19,8 @@ jobs:
     timeout-minutes: 10
     outputs:
       bump-viam: ${{ steps.viam.outputs.bump }}
+    env:
+      HOMEBREW_GITHUB_API_TOKEN: ${{ github.token }}
     steps:
     - name: Check out code
       uses: actions/checkout@v3

--- a/needs-bump.sh
+++ b/needs-bump.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# `needs-bump.sh formula` outputs 'true' if `formula` needs updating, otherwise 'false'
+
+set -eu
+
+FORMULA=${1-}
+
+if [ -z $FORMULA ]
+then
+	echo "Formula name missing or invalid"
+	exit 1
+fi
+
+CHECK=$(brew bump --no-fork --no-pull-requests $FORMULA)
+CUR_VERSION=$(echo "$CHECK" | grep Current | awk '{print $4}')
+NEW_VERSION=$(echo "$CHECK" | grep livecheck | awk '{print $4}')
+
+if [ $CUR_VERSION = $NEW_VERSION ]
+then
+	echo "false"
+else
+	echo "true"
+fi


### PR DESCRIPTION
## What changed
- needs-bump.sh outputs simple `true` / `false` when a bump is required
- trigger bottle.yml when needs-bump says to (only for `viam` formula for now i.e. the CLI)
## Why
So existing linux bottle doesn't get out of date with version bumps.
## Follow-ups needed
- bottle more architecures
- bottle more formulas
- error reporting