### PR TITLE
RSDK-5474 package CLI as bottle

### DIFF
--- a/.github/workflows/bottle.yml
+++ b/.github/workflows/bottle.yml
@@ -56,7 +56,7 @@ jobs:
           git status
           # brew pr-upload --root-url $ROOT_URL # tmp disable
           find $(brew --prefix) | grep -i taps.viamrobotics
-          cd $(brew --prefix)/Homebrew/Library/Taps/${{ github.repository }}
+          cd $(brew --prefix)/Library/Taps/${{ github.repository }}
           git status
 
       - name: push changes

--- a/.github/workflows/bottle.yml
+++ b/.github/workflows/bottle.yml
@@ -16,9 +16,6 @@ on:
 
 jobs:
   bottle:
-    concurrency:
-      # these make git commits and will fail if they overlap at all
-      group: bottle-mutex
     strategy:
       matrix:
         # macos-14 is apple silicon

--- a/.github/workflows/bottle.yml
+++ b/.github/workflows/bottle.yml
@@ -24,14 +24,9 @@ jobs:
         # macos-14 is apple silicon
         runs-on: [ubuntu-22.04, macos-14]
     runs-on: ${{ matrix.runs-on }}
-    permissions:
-      contents: write
-      packages: write
     steps:
-      - name: Set up Homebrew
-        uses: Homebrew/actions/setup-homebrew@master
-
-      # - uses: actions/checkout@v4
+      - uses: Homebrew/actions/setup-homebrew@master
+      - uses: actions/checkout@v4
 
       - name: git setup
         run: |
@@ -48,23 +43,36 @@ jobs:
         run: |
           brew tap viamrobotics/brews
           brew install --build-bottle ${{ inputs.formula }}
-          echo PRE
-          ls
           brew bottle --json --root-url $ROOT_URL ${{ inputs.formula }}
-          echo POST
-          ls *.bottle.*
-          git status
-          # brew pr-upload --root-url $ROOT_URL # tmp disable
-          find $(brew --prefix) | grep -i taps.viamrobotics
-          cd $(brew --prefix)/Library/Taps/${{ github.repository }}
-          git status
 
-      - name: push changes
-        if: false # tmp disable
-        run: |
-          cd $(brew --prefix)/Homebrew/Library/Taps/${{ github.repository }}
-          # note: the tap is on the current branch rather than main. not sure why, seems sensitive to whether we run actions/checkout.
-          # this will be run from main so this isn't a deal-breaker.
-          git log | head
-          git status
-          git push
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.runs-on }}
+          if-no-files-found: error
+          path: '*.bottle.*'
+
+  upload:
+    needs: bottle
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    steps:
+    - uses: Homebrew/actions/setup-homebrew@master
+    - uses: actions/checkout@v4
+
+    - name: download artifacts
+      run: |
+        brew tap viamrobotics/brews
+        for artifact in "ubuntu-22.04 macos-14"; do
+          echo artifact
+        done
+
+    - name: push changes
+      if: false # tmp disable
+      run: |
+        cd $(brew --prefix)/Homebrew/Library/Taps/${{ github.repository }}
+        # note: the tap is on the current branch rather than main. not sure why, seems sensitive to whether we run actions/checkout.
+        git log | head
+        git status
+        git push

--- a/.github/workflows/bottle.yml
+++ b/.github/workflows/bottle.yml
@@ -52,7 +52,8 @@ jobs:
           ls
           brew bottle --json --root-url $ROOT_URL ${{ inputs.formula }}
           echo POST
-          ls
+          ls *.bottle.*
+          git status
           # brew pr-upload --root-url $ROOT_URL # tmp disable
 
       - name: push changes

--- a/.github/workflows/bottle.yml
+++ b/.github/workflows/bottle.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Homebrew
         uses: Homebrew/actions/setup-homebrew@master
 
-      - uses: actions/checkout@v4
+      # - uses: actions/checkout@v4
 
       - name: git setup
         run: |

--- a/.github/workflows/bottle.yml
+++ b/.github/workflows/bottle.yml
@@ -55,6 +55,9 @@ jobs:
           ls *.bottle.*
           git status
           # brew pr-upload --root-url $ROOT_URL # tmp disable
+          find $(brew --prefix) | grep -i taps.viamrobotics
+          cd $(brew --prefix)/Homebrew/Library/Taps/${{ github.repository }}
+          git status
 
       - name: push changes
         if: false # tmp disable

--- a/.github/workflows/bottle.yml
+++ b/.github/workflows/bottle.yml
@@ -34,7 +34,7 @@ jobs:
           git config --global user.name "actions bot"
           git config push.autoSetupRemote true
 
-      - name: build and push bottle
+      - name: build bottle
         run: |
           brew tap viamrobotics/brews
           brew install --build-bottle ${{ inputs.formula }}

--- a/.github/workflows/bottle.yml
+++ b/.github/workflows/bottle.yml
@@ -64,9 +64,12 @@ jobs:
     - name: download artifacts
       run: |
         brew tap viamrobotics/brews
-        for artifact in "ubuntu-22.04 macos-14"; do
-          echo artifact
-        done
+        ls
+        gh run download ${{ github.run_id }}
+        ls
+        ls macos-14
+        mv */*.bottle.* .
+        ls
 
     - name: push changes
       if: false # tmp disable

--- a/.github/workflows/bottle.yml
+++ b/.github/workflows/bottle.yml
@@ -57,6 +57,12 @@ jobs:
     - uses: Homebrew/actions/setup-homebrew@master
     - uses: actions/checkout@v4
 
+    - name: git setup
+      run: |
+        git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git config --global user.name "actions bot"
+        git config push.autoSetupRemote true
+
     - name: download artifacts
       env:
         GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/bottle.yml
+++ b/.github/workflows/bottle.yml
@@ -14,6 +14,10 @@ on:
         default: viam
         description: which formula to bottle
 
+env:
+  # if you don't override root-url it will upload to / download from the wrong place
+  ROOT_URL: https://ghcr.io/v2/${{ github.repository }}
+
 jobs:
   bottle:
     strategy:
@@ -66,8 +70,6 @@ jobs:
       env:
         HOMEBREW_GITHUB_PACKAGES_USER: ${{ github.repository_owner }}
         HOMEBREW_GITHUB_PACKAGES_TOKEN: ${{ github.token }}
-        # if you don't override root-url it will upload to / download from the wrong place
-        ROOT_URL: https://ghcr.io/v2/${{ github.repository }}
       run: brew pr-upload --root-url $ROOT_URL
 
     - name: push changes

--- a/.github/workflows/bottle.yml
+++ b/.github/workflows/bottle.yml
@@ -32,11 +32,6 @@ jobs:
           git config push.autoSetupRemote true
 
       - name: build and push bottle
-        env:
-            HOMEBREW_GITHUB_PACKAGES_USER: ${{ github.repository_owner }}
-            HOMEBREW_GITHUB_PACKAGES_TOKEN: ${{ github.token }}
-            # if you don't override root-url it will upload to / download from the wrong place
-            ROOT_URL: https://ghcr.io/v2/${{ github.repository }}
         run: |
           brew tap viamrobotics/brews
           brew install --build-bottle ${{ inputs.formula }}
@@ -63,15 +58,19 @@ jobs:
         GH_TOKEN: ${{ github.token }}
       run: |
         brew tap viamrobotics/brews
-        ls
         gh run download ${{ github.run_id }}
-        ls
-        ls macos-14
         mv */*.bottle.* .
         ls
 
+    - name: upload
+      env:
+        HOMEBREW_GITHUB_PACKAGES_USER: ${{ github.repository_owner }}
+        HOMEBREW_GITHUB_PACKAGES_TOKEN: ${{ github.token }}
+        # if you don't override root-url it will upload to / download from the wrong place
+        ROOT_URL: https://ghcr.io/v2/${{ github.repository }}
+      run: brew pr-upload --root-url $ROOT_URL
+
     - name: push changes
-      if: false # tmp disable
       run: |
         cd $(brew --prefix)/Homebrew/Library/Taps/${{ github.repository }}
         # note: the tap is on the current branch rather than main. not sure why, seems sensitive to whether we run actions/checkout.

--- a/.github/workflows/bottle.yml
+++ b/.github/workflows/bottle.yml
@@ -22,8 +22,7 @@ jobs:
   bottle:
     strategy:
       matrix:
-        # macos-14 is apple silicon
-        runs-on: [ubuntu-22.04, macos-14]
+        runs-on: [ubuntu-22.04, macos-14, macos-15]
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: Homebrew/actions/setup-homebrew@master

--- a/.github/workflows/bottle.yml
+++ b/.github/workflows/bottle.yml
@@ -16,6 +16,9 @@ on:
 
 jobs:
   bottle:
+    concurrency:
+      # these make git commits and will fail if they overlap at all
+      group: bottle-mutex
     strategy:
       matrix:
         # macos-14 is apple silicon

--- a/.github/workflows/bottle.yml
+++ b/.github/workflows/bottle.yml
@@ -48,10 +48,15 @@ jobs:
         run: |
           brew tap viamrobotics/brews
           brew install --build-bottle ${{ inputs.formula }}
+          echo PRE
+          ls
           brew bottle --json --root-url $ROOT_URL ${{ inputs.formula }}
-          brew pr-upload --root-url $ROOT_URL
+          echo POST
+          ls
+          # brew pr-upload --root-url $ROOT_URL # tmp disable
 
       - name: push changes
+        if: false # tmp disable
         run: |
           cd $(brew --prefix)/Homebrew/Library/Taps/${{ github.repository }}
           # note: the tap is on the current branch rather than main. not sure why, seems sensitive to whether we run actions/checkout.

--- a/.github/workflows/bottle.yml
+++ b/.github/workflows/bottle.yml
@@ -62,6 +62,8 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: download artifacts
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: |
         brew tap viamrobotics/brews
         ls

--- a/.github/workflows/bottle.yml
+++ b/.github/workflows/bottle.yml
@@ -18,7 +18,8 @@ jobs:
   bottle:
     strategy:
       matrix:
-        runs-on: [ubuntu-22.04]
+        # macos-14 is apple silicon
+        runs-on: [ubuntu-22.04, macos-14]
     runs-on: ${{ matrix.runs-on }}
     permissions:
       contents: write

--- a/Formula/viam.rb
+++ b/Formula/viam.rb
@@ -7,8 +7,10 @@ class Viam < Formula
 
   bottle do
     root_url "https://ghcr.io/v2/viamrobotics/brews"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma: "29b11a40e465ea128aed49485c89d606465f084a16a11d373f82f594ff561a12"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "81b37348349dc500ce59cae47411fd7b0087385e3be51da0f360c8fea05b729c"
+    rebuild 2
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "1cf9e95bfde38d840cc29b5578fc82125da8cbdb8ebb55c3db7908a57ee09ee6"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "c84f4394a09492fe3c1a9d79e7b2078b0edf148675150d5bf386e9328fc56092"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "f949ea3c830f9cc88369dfc7fe97531d8a7da867aa65fb2089e36d2bee8bf977"
   end
 
   depends_on "go" => :build

--- a/Formula/viam.rb
+++ b/Formula/viam.rb
@@ -7,8 +7,8 @@ class Viam < Formula
 
   bottle do
     root_url "https://ghcr.io/v2/viamrobotics/brews"
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "e02baaca1ae314529251d8c360a2a659fc05896ce1fb69dee47ec88da2f3ee82"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma: "29b11a40e465ea128aed49485c89d606465f084a16a11d373f82f594ff561a12"
+    sha256 cellar: :any_skip_relocation, x86_64_linux: "81b37348349dc500ce59cae47411fd7b0087385e3be51da0f360c8fea05b729c"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
## What changed
- refactor bottling to build each architecture in a job, but upload all architectures together
## Why
Before I was doing the full bottle process sequentially for each platform (linux, macos-14, etc). That broke because the brew commands require that you upload all platforms at once. This PR's change allows us to support multiple platforms.
## Overview of build process
I think homebrew's recommended flow for this is to open a PR, then run the pr-upload command against that PR.

I think PR is not an option because we're bumping automatically. Instead I've done:
- `brew install --bottle` + `brew bottle` in per-architecture jobs
- ^ that created a bottle.tar.gz and a bottle.json which get uploaded as artifacts
- after all per-arch jobs are done, the uploader job downloads all artifacts to the working directory
- runs `brew pr-upload`, which uploads them to github packages
- and then does a commit to the repo which updates the bottles stanza in the formula
## Checklist
- [x] add macos 15