### PR TITLE
remove viam-server dependency on tensorflowlite

### DIFF
--- a/Formula/viam-server.rb
+++ b/Formula/viam-server.rb
@@ -13,7 +13,6 @@ class ViamServer < Formula
   depends_on "jpeg-turbo"
   depends_on "nlopt-static"
   depends_on "opus"
-  depends_on "tensorflowlite"
   depends_on "x264"
 
   def install


### PR DESCRIPTION
## What changed
- remove viam-server's tensorflowlite dependency
## Why
No longer needed and this is a long build.
## Manual test
I ran `brew remove tensorflowlite`, then `brew install viam-server`, and it succeeded.