### PR TITLE
bottle viam-server

### DIFF
--- a/.github/workflows/bottle.yml
+++ b/.github/workflows/bottle.yml
@@ -34,6 +34,7 @@ jobs:
       - name: build bottle
         run: |
           brew tap viamrobotics/brews
+          brew install --only-dependencies ${{ inputs.formula }}
           brew install --build-bottle ${{ inputs.formula }}
           brew bottle --json --root-url $ROOT_URL ${{ inputs.formula }}
 

--- a/.github/workflows/bottle.yml
+++ b/.github/workflows/bottle.yml
@@ -34,6 +34,8 @@ jobs:
       - name: build bottle
         run: |
           brew tap viamrobotics/brews
+          # note: this fails on the nlopt dep to viam-server when viam-server already exists as bottle in the formula file.
+          # weird edge case. recovery is to remove the bottle stanza and delete the uploaded package, then rerun.
           brew install --only-dependencies ${{ inputs.formula }}
           brew install --build-bottle ${{ inputs.formula }}
           brew bottle --json --root-url $ROOT_URL ${{ inputs.formula }}

--- a/.github/workflows/bottle.yml
+++ b/.github/workflows/bottle.yml
@@ -61,6 +61,11 @@ jobs:
         git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
         git config --global user.name "actions bot"
         git config push.autoSetupRemote true
+        git branch
+        # why pull: for the case where we are bottling two formulae, formula 1 will push a new commit.
+        # Then formula 2's bottle job will check out the original commit, try to push, and collid with
+        # formula 1's commit.
+        git pull
 
     - name: download artifacts
       env:

--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -19,6 +19,7 @@ jobs:
     timeout-minutes: 10
     outputs:
       bump-viam: ${{ steps.viam.outputs.bump }}
+      bump-viam-server: ${{ steps.viam-server.outputs.bump }}
     env:
       HOMEBREW_GITHUB_API_TOKEN: ${{ github.token }}
     steps:
@@ -37,7 +38,10 @@ jobs:
         brew developer on
 
     - name: Bump viam-server
-      run: ./bump-version.sh viam-server
+      id: viam-server
+      run: |
+        echo bump=$(./needs-bump.sh viam-server) >> "$GITHUB_OUTPUT"
+        ./bump-version.sh viam-server
 
     - name: Bump cartographer-module
       run: ./bump-version.sh cartographer-module
@@ -70,9 +74,22 @@ jobs:
 
   bottle-viam:
     needs: bump-versions
+    concurrency:
+      group: ${{ github.ref }}-bottle
     if: needs.bump-versions.outputs.bump-viam == 'true'
     uses: ./.github/workflows/bottle.yml
     with:
       formula: viam
+    secrets:
+      GIT_ACCESS_TOKEN: ${{ secrets.GIT_ACCESS_TOKEN }}
+
+  bottle-viam-server:
+    needs: bump-versions
+    concurrency:
+      group: ${{ github.ref }}-bottle
+    if: needs.bump-versions.outputs.bump-viam-server == 'true'
+    uses: ./.github/workflows/bottle.yml
+    with:
+      formula: viam-server
     secrets:
       GIT_ACCESS_TOKEN: ${{ secrets.GIT_ACCESS_TOKEN }}

--- a/Formula/viam-server.rb
+++ b/Formula/viam-server.rb
@@ -6,6 +6,14 @@ class ViamServer < Formula
   license "AGPL-3.0"
   head "https://github.com/viamrobotics/rdk.git", branch: "main"
 
+  bottle do
+    root_url "https://ghcr.io/v2/viamrobotics/brews"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "ef330423b8a46c0af3f76da19f2f27030164c928f0435cfc120a494667c862f9"
+    sha256 cellar: :any,                 arm64_sonoma:  "44bcbe54b0ab5deb67ae073753abe421e4c72d81398e8309f086bd3bf23266f8"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "12fe387b614ca2c742a159f5d4c150c208a23a1b14af0dfab8c82c9a854ffa00"
+  end
+
   depends_on "go" => :build
   depends_on "node@20" => :build
   depends_on "pkg-config" => :build

--- a/Formula/viam-server.rb
+++ b/Formula/viam-server.rb
@@ -7,6 +7,7 @@ class ViamServer < Formula
   head "https://github.com/viamrobotics/rdk.git", branch: "main"
 
   depends_on "go" => :build
+  depends_on "node@18" => :build
   depends_on "pkg-config" => :build
   depends_on "nlopt-static" => :build
   depends_on "ffmpeg"

--- a/Formula/viam-server.rb
+++ b/Formula/viam-server.rb
@@ -6,6 +6,14 @@ class ViamServer < Formula
   license "AGPL-3.0"
   head "https://github.com/viamrobotics/rdk.git", branch: "main"
 
+  bottle do
+    root_url "https://ghcr.io/v2/viamrobotics/brews"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "9920afb49bca480e24224e0d3d764091d5fb1e079798cfd7a6fedbfed21333fb"
+    sha256 cellar: :any,                 arm64_sonoma:  "d6ee26b655968605e2e74ec6601f3877c22e5601a725888370bdd046e50f23a8"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "c3bfb1680bfe9ed8c9e6d308299a6af862bb062fe401dc36bcb2df341bf49449"
+  end
+
   depends_on "go" => :build
   depends_on "node@20" => :build
   depends_on "pkg-config" => :build

--- a/Formula/viam-server.rb
+++ b/Formula/viam-server.rb
@@ -9,9 +9,9 @@ class ViamServer < Formula
   depends_on "go" => :build
   depends_on "node@18" => :build
   depends_on "pkg-config" => :build
+  depends_on "nlopt-static" => :build
   depends_on "ffmpeg"
   depends_on "jpeg-turbo"
-  depends_on "nlopt-static"
   depends_on "opus"
   depends_on "x264"
 

--- a/Formula/viam-server.rb
+++ b/Formula/viam-server.rb
@@ -6,14 +6,6 @@ class ViamServer < Formula
   license "AGPL-3.0"
   head "https://github.com/viamrobotics/rdk.git", branch: "main"
 
-  bottle do
-    root_url "https://ghcr.io/v2/viamrobotics/brews"
-    rebuild 1
-    sha256 cellar: :any,                 arm64_sequoia: "ef330423b8a46c0af3f76da19f2f27030164c928f0435cfc120a494667c862f9"
-    sha256 cellar: :any,                 arm64_sonoma:  "44bcbe54b0ab5deb67ae073753abe421e4c72d81398e8309f086bd3bf23266f8"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "12fe387b614ca2c742a159f5d4c150c208a23a1b14af0dfab8c82c9a854ffa00"
-  end
-
   depends_on "go" => :build
   depends_on "node@20" => :build
   depends_on "pkg-config" => :build

--- a/Formula/viam-server.rb
+++ b/Formula/viam-server.rb
@@ -17,9 +17,9 @@ class ViamServer < Formula
   depends_on "go" => :build
   depends_on "node@20" => :build
   depends_on "pkg-config" => :build
-  depends_on "nlopt-static" => :build
   depends_on "ffmpeg"
   depends_on "jpeg-turbo"
+  depends_on "nlopt-static"
   depends_on "opus"
   depends_on "x264"
 

--- a/Formula/viam-server.rb
+++ b/Formula/viam-server.rb
@@ -7,7 +7,6 @@ class ViamServer < Formula
   head "https://github.com/viamrobotics/rdk.git", branch: "main"
 
   depends_on "go" => :build
-  depends_on "node@18" => :build
   depends_on "pkg-config" => :build
   depends_on "nlopt-static" => :build
   depends_on "ffmpeg"

--- a/Formula/viam-server.rb
+++ b/Formula/viam-server.rb
@@ -7,7 +7,7 @@ class ViamServer < Formula
   head "https://github.com/viamrobotics/rdk.git", branch: "main"
 
   depends_on "go" => :build
-  depends_on "node@18" => :build
+  depends_on "node@20" => :build
   depends_on "pkg-config" => :build
   depends_on "nlopt-static" => :build
   depends_on "ffmpeg"

--- a/Formula/viam.rb
+++ b/Formula/viam.rb
@@ -7,10 +7,10 @@ class Viam < Formula
 
   bottle do
     root_url "https://ghcr.io/v2/viamrobotics/brews"
-    rebuild 3
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "6b26b90a6cb35fbfa07abbc8f0e9d58165ddaaeac37d421c31f6140a395aa11d"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "17e8fc7dd10fb700d3564abe81f179f0ebf03119d84a5bc6fcbc13ceebeb685f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "da7199b650cc9a29f90fe1eabaeef187e4594d9118c20a4b28228184ca635721"
+    rebuild 4
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "140334cd202a15da009ad3493cf9a46d51bf98ad48dd9f27a5a5f98dc6ae262a"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "dda89ee677ee6b43d9a8b09d23b3021e9c6244a7442d97e3ffb6f946a9574f64"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "2b11c124c1683d39112b1d8986e38c88e1181b5c7e04b66f3071081f00cbe305"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
## What changed
- bottle viam-server (previously we were bottling only viam CLI)
- when bottling, install depends in a separate step from building the bottle. otherwise this tries to bottle nlopt and fails ([example](https://github.com/viamrobotics/homebrew-brews/actions/runs/11806813603/job/32892222602#step:4:189))
- in viam-server formula, bump node 18 -> 20 bc of deprecation warning. node is going away soon here anyway I think
## Why
Takes a while to build, tough first try / new laptop experience
## Testing
- successful CI run https://github.com/viamrobotics/homebrew-brews/actions/runs/11807743220
- [x] download the bottle and try running the binary on a random mac (to make sure the linking makes sense)