### PR TITLE
fix viam-server build

### DIFF
--- a/.github/workflows/bottle.yml
+++ b/.github/workflows/bottle.yml
@@ -37,16 +37,13 @@ jobs:
 
       - name: build bottle
         run: |
+          # without this force-install, the pkgconf dep of viam-server conflicts with the one github preinstalls on runners, and the build fails
           brew install --force --overwrite pkg-config
+
           brew tap viamrobotics/brews
           # note: this fails on the nlopt dep to viam-server when viam-server already exists as bottle in the formula file.
           # weird edge case. recovery is to remove the bottle stanza and delete the uploaded package, then rerun.
           brew install --only-dependencies ${{ inputs.formula }}
-
-          # without this install+link step, the job fails on CI runners
-          # brew install pkgconf
-          # brew link --overwrite pkgconf
-
           brew install --build-bottle ${{ inputs.formula }}
           brew bottle --json --root-url $ROOT_URL ${{ inputs.formula }}
 

--- a/.github/workflows/bottle.yml
+++ b/.github/workflows/bottle.yml
@@ -43,10 +43,10 @@ jobs:
           brew install --only-dependencies ${{ inputs.formula }}
 
           # without this install+link step, the job fails on CI runners
-          brew install pkgconf
-          brew link --overwrite pkgconf
+          # brew install pkgconf
+          # brew link --overwrite pkgconf
 
-          brew install --build-bottle ${{ inputs.formula }}
+          brew install --overwrite --build-bottle ${{ inputs.formula }}
           brew bottle --json --root-url $ROOT_URL ${{ inputs.formula }}
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/bottle.yml
+++ b/.github/workflows/bottle.yml
@@ -41,8 +41,11 @@ jobs:
           # note: this fails on the nlopt dep to viam-server when viam-server already exists as bottle in the formula file.
           # weird edge case. recovery is to remove the bottle stanza and delete the uploaded package, then rerun.
           brew install --only-dependencies ${{ inputs.formula }}
-          # without this link step this fails on macos-15 runner
+
+          # without this install+link step, the job fails on CI runners
+          brew install pkgconf
           brew link --overwrite pkgconf
+
           brew install --build-bottle ${{ inputs.formula }}
           brew bottle --json --root-url $ROOT_URL ${{ inputs.formula }}
 

--- a/.github/workflows/bottle.yml
+++ b/.github/workflows/bottle.yml
@@ -37,12 +37,11 @@ jobs:
 
       - name: build bottle
         run: |
-          # without this, macos-15 fails with a brew link error
-          brew unlink pkg-config
           brew tap viamrobotics/brews
           # note: this fails on the nlopt dep to viam-server when viam-server already exists as bottle in the formula file.
           # weird edge case. recovery is to remove the bottle stanza and delete the uploaded package, then rerun.
-          brew install --only-dependencies ${{ inputs.formula }}
+          # note: --overwrite is necessary on macos-15 CI runners where pkg-config is already present; otherwise build fails.
+          brew install --overwrite --only-dependencies ${{ inputs.formula }}
           brew install --build-bottle ${{ inputs.formula }}
           brew bottle --json --root-url $ROOT_URL ${{ inputs.formula }}
 

--- a/.github/workflows/bottle.yml
+++ b/.github/workflows/bottle.yml
@@ -37,6 +37,7 @@ jobs:
 
       - name: build bottle
         run: |
+          brew install --force --overwrite pkg-config
           brew tap viamrobotics/brews
           # note: this fails on the nlopt dep to viam-server when viam-server already exists as bottle in the formula file.
           # weird edge case. recovery is to remove the bottle stanza and delete the uploaded package, then rerun.
@@ -46,7 +47,7 @@ jobs:
           # brew install pkgconf
           # brew link --overwrite pkgconf
 
-          brew install --overwrite --build-bottle ${{ inputs.formula }}
+          brew install --build-bottle ${{ inputs.formula }}
           brew bottle --json --root-url $ROOT_URL ${{ inputs.formula }}
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/bottle.yml
+++ b/.github/workflows/bottle.yml
@@ -40,8 +40,8 @@ jobs:
           brew tap viamrobotics/brews
           # note: this fails on the nlopt dep to viam-server when viam-server already exists as bottle in the formula file.
           # weird edge case. recovery is to remove the bottle stanza and delete the uploaded package, then rerun.
-          # note: --overwrite is necessary on macos-15 CI runners where pkg-config is already present; otherwise build fails.
-          brew install --overwrite --only-dependencies ${{ inputs.formula }}
+          # without --force, build fails on macos 15 runner with brew link error
+          brew install --force --only-dependencies ${{ inputs.formula }}
           brew install --build-bottle ${{ inputs.formula }}
           brew bottle --json --root-url $ROOT_URL ${{ inputs.formula }}
 

--- a/.github/workflows/bottle.yml
+++ b/.github/workflows/bottle.yml
@@ -40,8 +40,9 @@ jobs:
           brew tap viamrobotics/brews
           # note: this fails on the nlopt dep to viam-server when viam-server already exists as bottle in the formula file.
           # weird edge case. recovery is to remove the bottle stanza and delete the uploaded package, then rerun.
-          # without --force, build fails on macos 15 runner with brew link error
-          brew install --force --only-dependencies ${{ inputs.formula }}
+          brew install --only-dependencies ${{ inputs.formula }}
+          # without this link step this fails on macos-15 runner
+          brew link --overwrite pkgconf
           brew install --build-bottle ${{ inputs.formula }}
           brew bottle --json --root-url $ROOT_URL ${{ inputs.formula }}
 

--- a/.github/workflows/bottle.yml
+++ b/.github/workflows/bottle.yml
@@ -37,6 +37,8 @@ jobs:
 
       - name: build bottle
         run: |
+          # without this, macos-15 fails with a brew link error
+          brew unlink pkg-config
           brew tap viamrobotics/brews
           # note: this fails on the nlopt dep to viam-server when viam-server already exists as bottle in the formula file.
           # weird edge case. recovery is to remove the bottle stanza and delete the uploaded package, then rerun.

--- a/Formula/viam-server.rb
+++ b/Formula/viam-server.rb
@@ -16,7 +16,7 @@ class ViamServer < Formula
 
   depends_on "go" => :build
   depends_on "node@20" => :build
-  depends_on "pkg-config" => :build
+  depends_on "pkgconf" => :build
   depends_on "ffmpeg"
   depends_on "jpeg-turbo"
   depends_on "nlopt-static"

--- a/Formula/viam-server.rb
+++ b/Formula/viam-server.rb
@@ -16,7 +16,6 @@ class ViamServer < Formula
 
   depends_on "go" => :build
   depends_on "node@20" => :build
-  depends_on "pkgconf" => :build
   depends_on "ffmpeg"
   depends_on "jpeg-turbo"
   depends_on "nlopt-static"

--- a/Formula/viam-server.rb
+++ b/Formula/viam-server.rb
@@ -8,10 +8,10 @@ class ViamServer < Formula
 
   bottle do
     root_url "https://ghcr.io/v2/viamrobotics/brews"
-    rebuild 1
-    sha256 cellar: :any,                 arm64_sequoia: "9920afb49bca480e24224e0d3d764091d5fb1e079798cfd7a6fedbfed21333fb"
-    sha256 cellar: :any,                 arm64_sonoma:  "d6ee26b655968605e2e74ec6601f3877c22e5601a725888370bdd046e50f23a8"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "c3bfb1680bfe9ed8c9e6d308299a6af862bb062fe401dc36bcb2df341bf49449"
+    rebuild 2
+    sha256 cellar: :any,                 arm64_sequoia: "7d40da6d357e1c30dfb011748059d30a4d36ad19f551fb09a76ed3a2be2b9ac4"
+    sha256 cellar: :any,                 arm64_sonoma:  "206ea1f2bc5febfc797018ae50a7e581300f1c60f7e171f9d4b64b349783af08"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "aacd0b93a67552ceee91c6e47abdffe4b546c59048820e519f5dfc384a16506e"
   end
 
   depends_on "go" => :build

--- a/Formula/viam-server.rb
+++ b/Formula/viam-server.rb
@@ -16,6 +16,7 @@ class ViamServer < Formula
 
   depends_on "go" => :build
   depends_on "node@20" => :build
+  depends_on "pkg-config" => :build
   depends_on "ffmpeg"
   depends_on "jpeg-turbo"
   depends_on "nlopt-static"

--- a/Formula/viam.rb
+++ b/Formula/viam.rb
@@ -7,10 +7,10 @@ class Viam < Formula
 
   bottle do
     root_url "https://ghcr.io/v2/viamrobotics/brews"
-    rebuild 7
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "7893b4e959c9a016fdbbe0f5a04da1fdf638756a25b75c2b0d3607b4919fdbb0"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "c4497af324b1364efec34d5c7de00f6d112c49d8c4a34b80f8c25905facd872c"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "aba1f36f486f1c2ad1445cf5f9fb5064cb32b627a21ca703cae739b9a7ac92e5"
+    rebuild 8
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "4d3adfbee15a8f2e7bd892fa69ce5a68d01495687fa3a5d367b74cf6ad03f990"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "699f771c69548f63ff0297fdcef95ecafafe90887df792c220d92116a62df742"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "97887fda9405f4e94cade3daf256b5f78f40faf366c96463a6e95a47a5fce59b"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
## What changed
- preinstall pkg-config at the top of bottling
## Why
Otherwise, viam-server build fails (but only in runners, where there's a random conflicting pkg-config installation)