### PR TITLE
RSDK-8395: Workaround homebrew change that broke recipe

### DIFF
--- a/Formula/viam-cpp-sdk.rb
+++ b/Formula/viam-cpp-sdk.rb
@@ -19,7 +19,7 @@ class ViamCppSdk < Formula
   depends_on "buf"
 
   def install
-    system "cmake", "-S", ".", "-B", "build", *std_cmake_args
+    system "cmake", "-S", ".", "-B", "build", "-DFETCHCONTENT_FULLY_DISCONNECTED=ON", "-DHOMEBREW_ALLOW_FETCHCONTENT=ON", *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
   end


### PR DESCRIPTION
Following the error message posted in the ticket:

> CMake Error at /opt/homebrew/Library/Homebrew/cmake/trap_fetchcontent_provider.cmake:12 (message):
>   Refusing to populate dependency 'xtl' with FetchContent while building in
>   Homebrew, please use a formula dependency or add a resource to the formula.

Homebrew used to pass `FETCHCONTENT_FULLY_DISCONNECTED=ON` to CMake, which made it so that FetchContent would never actually pull anything from online. However we were using the signature of FetchContent with [`find_package` integration](https://cmake.org/cmake/help/latest/module/FetchContent.html#integrating-with-find-package) so this was able to handle the homebrew case transparently, because it was just calling `find_package` and using the version in our brew formula. However https://github.com/Homebrew/brew/pull/17310 broke our formula, and this happened to at least one other formula: https://github.com/houmain/homebrew-tap/pull/1

Now we
- pass the flag to manually enable fetchcontent support; but
- also pass the flag that homebrew used to pass to disable FetchContent, restoring the old behavior of falling back to find_package