### PR TITLE
pin brew container to fix builds

### DIFF
--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -25,8 +25,6 @@ jobs:
       # HOMEBREW_NO_AUTO_UPDATE: '1'
       # HOMEBREW_NO_INSTALL_FROM_API: '1'
     steps:
-    # - name: cd
-    #   run: cd ~linuxbrew
     - name: Check out code
       uses: actions/checkout@v3
       with:
@@ -34,12 +32,7 @@ jobs:
         token: ${{ secrets.GIT_ACCESS_TOKEN }}
 
     - name: Setup homebrew and git config
-      run: |
-        mkdir /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/viamrobotics
-        ln -s $(pwd) /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/viamrobotics/homebrew-brews
-        git config --global --add safe.directory '*'
-        git config --global url."https://github.com/".insteadOf git@github.com:
-        brew developer on
+      run: ./fake-tap.sh
 
     - name: Bump viam-server
       id: viam-server

--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -24,7 +24,7 @@ jobs:
       HOMEBREW_GITHUB_API_TOKEN: ${{ github.token }}
     steps:
     - name: cd
-      run: cd
+      run: cd $HOME
     - name: Check out code
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -22,6 +22,8 @@ jobs:
       bump-viam-server: ${{ steps.viam-server.outputs.bump }}
     env:
       HOMEBREW_GITHUB_API_TOKEN: ${{ github.token }}
+      HOMEBREW_NO_AUTO_UPDATE: '1'
+      HOMEBREW_NO_INSTALL_FROM_API: '1'
     steps:
     # - name: cd
     #   run: cd ~linuxbrew

--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -32,7 +32,7 @@ jobs:
         token: ${{ secrets.GIT_ACCESS_TOKEN }}
 
     - name: Setup homebrew and git config
-      run: ./fake-tap.sh
+      run: brew tap viamrobotics/brews
 
     - name: Bump viam-server
       id: viam-server

--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   bump-versions:
     name: Bump Package Versions
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     container:
       # pinning because --write-only flag seems broken on newer, need to investigate
       image: homebrew/brew@sha256:1e8baee8fa03a31726d50ec5d77635991c3f22d045a3e450e8dcedcb63161bc3

--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -35,8 +35,8 @@ jobs:
 
     - name: Setup homebrew and git config
       run: |
-        brew --version
         ./fake-tap.sh
+        brew --version
 
     - name: Bump viam-server
       id: viam-server

--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -22,8 +22,8 @@ jobs:
       bump-viam-server: ${{ steps.viam-server.outputs.bump }}
     env:
       HOMEBREW_GITHUB_API_TOKEN: ${{ github.token }}
-      HOMEBREW_NO_AUTO_UPDATE: '1'
-      HOMEBREW_NO_INSTALL_FROM_API: '1'
+      # HOMEBREW_NO_AUTO_UPDATE: '1'
+      # HOMEBREW_NO_INSTALL_FROM_API: '1'
     steps:
     # - name: cd
     #   run: cd ~linuxbrew

--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -24,7 +24,7 @@ jobs:
       HOMEBREW_GITHUB_API_TOKEN: ${{ github.token }}
     steps:
     - name: cd
-      run: cd $HOME
+      run: cd ~linuxbrew
     - name: Check out code
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -10,20 +10,99 @@ on:
   workflow_dispatch:
 
 jobs:
-  bump-action:
-    runs-on: ubuntu-latest
+  bump-versions:
+    name: Bump Package Versions
+    runs-on: ubuntu-22.04
+    container:
+      image: homebrew/brew
+      options: --user root
+    timeout-minutes: 10
+    outputs:
+      bump-viam: ${{ steps.viam.outputs.bump }}
+      bump-viam-server: ${{ steps.viam-server.outputs.bump }}
+    env:
+      HOMEBREW_GITHUB_API_TOKEN: ${{ github.token }}
+      # HOMEBREW_NO_AUTO_UPDATE: '1'
+      # HOMEBREW_NO_INSTALL_FROM_API: '1'
     steps:
-    - uses: Homebrew/actions/setup-homebrew@bc624b9b4073985ee647eba2507305b15c9404ce
-    - uses: homebrew/actions/bump-packages@bc624b9b4073985ee647eba2507305b15c9404ce
-      id: bump
+    # - name: cd
+    #   run: cd ~linuxbrew
+    - name: Check out code
+      uses: actions/checkout@v3
       with:
-        token: ${{ github.token }}
-        formulae: >
-          viam-server
-          cartographer-module
-          rplidar-module
-          orb-slam3-module
-          canon
-          viam-dialdbg
-          viam-cpp-sdk
-        fork: false
+        ref: ${{ github.head_ref }}
+        token: ${{ secrets.GIT_ACCESS_TOKEN }}
+
+    - name: Setup homebrew and git config
+      run: |
+        mkdir /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/viamrobotics
+        ln -s $(pwd) /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/viamrobotics/homebrew-brews
+        git config --global --add safe.directory '*'
+        git config --global url."https://github.com/".insteadOf git@github.com:
+        brew developer on
+
+    - name: Bump viam-server
+      id: viam-server
+      run: |
+        echo bump=$(./needs-bump.sh viam-server) >> "$GITHUB_OUTPUT"
+        ./bump-version.sh viam-server
+
+    - name: Bump cartographer-module
+      run: ./bump-version.sh cartographer-module
+
+    - name: Bump rplidar-module
+      run: ./bump-version.sh rplidar-module
+
+    - name: Bump orb-slam3-module
+      run: ./bump-version.sh orb-slam3-module
+
+    - name: Bump canon
+      run: ./bump-version.sh canon
+
+    - name: Bump viam-dialdbg
+      run: ./bump-version.sh viam-dialdbg
+
+    - name: Bump viam-cpp-sdk
+      run: ./bump-version.sh viam-cpp-sdk
+
+    - name: Bump viam
+      id: viam
+      run: |
+        echo bump=$(./needs-bump.sh viam) >> "$GITHUB_OUTPUT"
+        ./bump-version.sh viam
+
+    - name: Commit changes
+      uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+        commit_message: Auto-update of package versions
+
+  bottle-viam:
+    needs: bump-versions
+    concurrency:
+      group: ${{ github.ref }}-bottle
+    if: needs.bump-versions.outputs.bump-viam == 'true'
+    uses: ./.github/workflows/bottle.yml
+    with:
+      formula: viam
+    secrets:
+      GIT_ACCESS_TOKEN: ${{ secrets.GIT_ACCESS_TOKEN }}
+
+  bottle-viam-server:
+    if: needs.bump-versions.outputs.bump-viam-server == 'true'
+    needs: bump-versions
+    concurrency:
+      group: ${{ github.ref }}-bottle
+    uses: ./.github/workflows/bottle.yml
+    with:
+      formula: viam-server
+    secrets:
+      GIT_ACCESS_TOKEN: ${{ secrets.GIT_ACCESS_TOKEN }}
+
+  upload:
+    needs: [bottle-viam, bottle-viam-server]
+    if: |
+      needs.bottle-viam.result == 'success' || 
+      needs.bottle-viam-server.result == 'success'
+    uses: ./.github/workflows/upload.yml
+    secrets:
+      GIT_ACCESS_TOKEN: ${{ secrets.GIT_ACCESS_TOKEN }}

--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -10,99 +10,18 @@ on:
   workflow_dispatch:
 
 jobs:
-  bump-versions:
-    name: Bump Package Versions
-    runs-on: ubuntu-22.04
-    container:
-      image: homebrew/brew
-      options: --user root
-    timeout-minutes: 10
-    outputs:
-      bump-viam: ${{ steps.viam.outputs.bump }}
-      bump-viam-server: ${{ steps.viam-server.outputs.bump }}
-    env:
-      HOMEBREW_GITHUB_API_TOKEN: ${{ github.token }}
-      # HOMEBREW_NO_AUTO_UPDATE: '1'
-      # HOMEBREW_NO_INSTALL_FROM_API: '1'
+  bump-action:
+    runs-on: ubuntu-latest
     steps:
-    # - name: cd
-    #   run: cd ~linuxbrew
-    - name: Check out code
-      uses: actions/checkout@v3
+    - uses: homebrew/actions/bump-packages@bc624b9b4073985ee647eba2507305b15c9404ce
       with:
-        ref: ${{ github.head_ref }}
-        token: ${{ secrets.GIT_ACCESS_TOKEN }}
-
-    - name: Setup homebrew and git config
-      run: |
-        mkdir /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/viamrobotics
-        ln -s $(pwd) /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/viamrobotics/homebrew-brews
-        git config --global --add safe.directory '*'
-        git config --global url."https://github.com/".insteadOf git@github.com:
-        brew developer on
-
-    - name: Bump viam-server
-      id: viam-server
-      run: |
-        echo bump=$(./needs-bump.sh viam-server) >> "$GITHUB_OUTPUT"
-        ./bump-version.sh viam-server
-
-    - name: Bump cartographer-module
-      run: ./bump-version.sh cartographer-module
-
-    - name: Bump rplidar-module
-      run: ./bump-version.sh rplidar-module
-
-    - name: Bump orb-slam3-module
-      run: ./bump-version.sh orb-slam3-module
-
-    - name: Bump canon
-      run: ./bump-version.sh canon
-
-    - name: Bump viam-dialdbg
-      run: ./bump-version.sh viam-dialdbg
-
-    - name: Bump viam-cpp-sdk
-      run: ./bump-version.sh viam-cpp-sdk
-
-    - name: Bump viam
-      id: viam
-      run: |
-        echo bump=$(./needs-bump.sh viam) >> "$GITHUB_OUTPUT"
-        ./bump-version.sh viam
-
-    - name: Commit changes
-      uses: stefanzweifel/git-auto-commit-action@v4
-      with:
-        commit_message: Auto-update of package versions
-
-  bottle-viam:
-    needs: bump-versions
-    concurrency:
-      group: ${{ github.ref }}-bottle
-    if: needs.bump-versions.outputs.bump-viam == 'true'
-    uses: ./.github/workflows/bottle.yml
-    with:
-      formula: viam
-    secrets:
-      GIT_ACCESS_TOKEN: ${{ secrets.GIT_ACCESS_TOKEN }}
-
-  bottle-viam-server:
-    if: needs.bump-versions.outputs.bump-viam-server == 'true'
-    needs: bump-versions
-    concurrency:
-      group: ${{ github.ref }}-bottle
-    uses: ./.github/workflows/bottle.yml
-    with:
-      formula: viam-server
-    secrets:
-      GIT_ACCESS_TOKEN: ${{ secrets.GIT_ACCESS_TOKEN }}
-
-  upload:
-    needs: [bottle-viam, bottle-viam-server]
-    if: |
-      needs.bottle-viam.result == 'success' || 
-      needs.bottle-viam-server.result == 'success'
-    uses: ./.github/workflows/upload.yml
-    secrets:
-      GIT_ACCESS_TOKEN: ${{ secrets.GIT_ACCESS_TOKEN }}
+        token: ${{ github.token }}
+        formulae: >
+          viam-server
+          cartographer-module
+          rplidar-module
+          orb-slam3-module
+          canon
+          viam-dialdbg
+          viam-cpp-sdk
+        fork: false

--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -12,10 +12,10 @@ on:
 jobs:
   bump-versions:
     name: Bump Package Versions
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: homebrew/brew
-      # options: --user root
+      options: --user root
     timeout-minutes: 10
     outputs:
       bump-viam: ${{ steps.viam.outputs.bump }}
@@ -23,8 +23,8 @@ jobs:
     env:
       HOMEBREW_GITHUB_API_TOKEN: ${{ github.token }}
     steps:
-    - name: cd
-      run: cd ~linuxbrew
+    # - name: cd
+    #   run: cd ~linuxbrew
     - name: Check out code
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -13,7 +13,9 @@ jobs:
   bump-action:
     runs-on: ubuntu-latest
     steps:
+    - uses: Homebrew/actions/setup-homebrew@bc624b9b4073985ee647eba2507305b15c9404ce
     - uses: homebrew/actions/bump-packages@bc624b9b4073985ee647eba2507305b15c9404ce
+      id: bump
       with:
         token: ${{ github.token }}
         formulae: >

--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -14,7 +14,8 @@ jobs:
     name: Bump Package Versions
     runs-on: ubuntu-22.04
     container:
-      image: homebrew/brew
+      # pinning because --write-only flag seems broken on newer, need to investigate
+      image: homebrew/brew@sha256:1e8baee8fa03a31726d50ec5d77635991c3f22d045a3e450e8dcedcb63161bc3
       options: --user root
     timeout-minutes: 10
     outputs:
@@ -22,8 +23,9 @@ jobs:
       bump-viam-server: ${{ steps.viam-server.outputs.bump }}
     env:
       HOMEBREW_GITHUB_API_TOKEN: ${{ github.token }}
-      # HOMEBREW_NO_AUTO_UPDATE: '1'
-      # HOMEBREW_NO_INSTALL_FROM_API: '1'
+      # these no-update flags are to prevent us from (defeats the purpose of pinning)
+      HOMEBREW_NO_AUTO_UPDATE: '1'
+      HOMEBREW_NO_INSTALL_FROM_API: '1'
     steps:
     - name: Check out code
       uses: actions/checkout@v3
@@ -32,7 +34,9 @@ jobs:
         token: ${{ secrets.GIT_ACCESS_TOKEN }}
 
     - name: Setup homebrew and git config
-      run: brew tap viamrobotics/brews
+      run: |
+        brew version
+        ./fake-tap.sh
 
     - name: Bump viam-server
       id: viam-server

--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -23,6 +23,8 @@ jobs:
     env:
       HOMEBREW_GITHUB_API_TOKEN: ${{ github.token }}
     steps:
+    - name: cd
+      run: cd
     - name: Check out code
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -35,7 +35,7 @@ jobs:
 
     - name: Setup homebrew and git config
       run: |
-        brew version
+        brew --version
         ./fake-tap.sh
 
     - name: Bump viam-server

--- a/Formula/viam-cpp-sdk.rb
+++ b/Formula/viam-cpp-sdk.rb
@@ -2,8 +2,8 @@ class ViamCppSdk < Formula
   desc "Viam C++ SDK"
   homepage "https://www.viam.com/"
   url "https://github.com/viamrobotics/viam-cpp-sdk.git",
-    tag:      "releases/v0.10.0",
-    revision: "faa73b6c3edefdde9a1aa618223cdb1f3e986d2a"
+    tag:      "releases/v0.11.0",
+    revision: "d175d669227aea18390a269cf0d8139e12792672"
   license "Apache-2.0"
   head "https://github.com/viamrobotics/viam-cpp-sdk.git", branch: "main"
 

--- a/Formula/viam-server.rb
+++ b/Formula/viam-server.rb
@@ -1,8 +1,8 @@
 class ViamServer < Formula
   desc "Main server application of the viam robot development kit (RDK)"
   homepage "https://www.viam.com/"
-  url "https://github.com/viamrobotics/rdk/archive/refs/tags/v0.72.1.tar.gz"
-  sha256 "559c20b6ba7ab5cf7bf2ae3d9b0ac46739c8ff889d1967f2a4a03fb7eceefb0a"
+  url "https://github.com/viamrobotics/rdk/archive/refs/tags/v0.73.1.tar.gz"
+  sha256 "57c409bbdfa0fa5269f6c4b318c0e8c21a5ebff836a207f0e1f7c23553467e93"
   license "AGPL-3.0"
   head "https://github.com/viamrobotics/rdk.git", branch: "main"
 

--- a/Formula/viam-server.rb
+++ b/Formula/viam-server.rb
@@ -48,7 +48,7 @@ class ViamServer < Formula
   service do
     log_path var/"log/viam.log"
     error_log_path var/"log/viam.log"
-    run [bin/"viam-server", "-config", etc/"viam.json"]
+    run [opt_bin/"viam-server", "-config", etc/"viam.json"]
   end
 
   def caveats

--- a/Formula/viam-server.rb
+++ b/Formula/viam-server.rb
@@ -48,7 +48,7 @@ class ViamServer < Formula
   service do
     log_path var/"log/viam.log"
     error_log_path var/"log/viam.log"
-    run [opt_bin/"viam-server", "-config", etc/"viam.json"]
+    run [bin/"viam-server", "-config", etc/"viam.json"]
   end
 
   def caveats

--- a/Formula/viam-server.rb
+++ b/Formula/viam-server.rb
@@ -8,10 +8,9 @@ class ViamServer < Formula
 
   bottle do
     root_url "https://ghcr.io/v2/viamrobotics/brews"
-    rebuild 33
-    sha256 cellar: :any,                 arm64_sequoia: "800ec8fdf176f055071a258838393bada2587838770d8aaebb3ea2551393e7a5"
-    sha256 cellar: :any,                 arm64_sonoma:  "f96318fa3763c6627214a83cc43a3c0691e90ccb2754d0bca10f17ea4c289486"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "97d6026517adb858743318a399dc09e2a53e14ef512f5f826fc1a7cfd6c04758"
+    sha256 cellar: :any,                 arm64_sequoia: "9ae8a679e37d26ebc8fed3c74ce4c1e7da11a60c152c084afa0aa2735cdac356"
+    sha256 cellar: :any,                 arm64_sonoma:  "3637ae1c765598a2147c326f2a2ff5e3280035fb2c317b8f9bea9aa291e76c6b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "bb87391e3aa14cc9a0ccc3bd0930e1a12f89b143128d5edca9af457320807dc1"
   end
 
   depends_on "go" => :build

--- a/Formula/viam.rb
+++ b/Formula/viam.rb
@@ -1,8 +1,8 @@
 class Viam < Formula
   desc "CLI for managing robots, orgs, etc. (See viam-server for running a robot)"
   homepage "https://docs.viam.com/cli/"
-  url "https://github.com/viamrobotics/rdk/archive/refs/tags/v0.72.1.tar.gz"
-  sha256 "559c20b6ba7ab5cf7bf2ae3d9b0ac46739c8ff889d1967f2a4a03fb7eceefb0a"
+  url "https://github.com/viamrobotics/rdk/archive/refs/tags/v0.73.1.tar.gz"
+  sha256 "57c409bbdfa0fa5269f6c4b318c0e8c21a5ebff836a207f0e1f7c23553467e93"
   head "https://github.com/viamrobotics/rdk.git", branch: "main"
 
   bottle do

--- a/Formula/viam.rb
+++ b/Formula/viam.rb
@@ -7,10 +7,9 @@ class Viam < Formula
 
   bottle do
     root_url "https://ghcr.io/v2/viamrobotics/brews"
-    rebuild 36
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "eee103eb8048cfd0621a0892dd2e15718a65a4b8faa7aff7b9cb57e32c22b9f0"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "c9736e0f375493b17b90e82ed1653e84749bf5cdfdf91e75ecd9b4120ba5c2e6"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "93a894e7da5e890e846427483b3b04296dcc90d7eda2dde71fd4497009ae3636"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "e6730f64415b9bacc012ed11e882e0ffe784f8b7767a487f4ef0b997903a99e7"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "48edca395da1e5f5c2bc295283baa714a23d98b3315fd457969163a88b7df688"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "54f4ed8cd2b09ca155bd3a96429f60e409a3956c86941312556a542d623435a0"
   end
 
   depends_on "go" => :build

--- a/bump-version.sh
+++ b/bump-version.sh
@@ -19,4 +19,5 @@ then
 	exit 0
 fi
 
-brew bump-formula-pr --write-only --version $NEW_VERSION --no-audit $FORMULA
+# note: --write-only flag here means that it doesn't open a PR
+brew bump-formula-pr --write-only --version $NEW_VERSION --no-fork --no-audit $FORMULA

--- a/bump-version.sh
+++ b/bump-version.sh
@@ -19,4 +19,4 @@ then
 	exit 0
 fi
 
-brew bump-formula-pr --write-only --version $NEW_VERSION --no-fork $FORMULA
+brew bump-formula-pr --write-only --version $NEW_VERSION --no-fork --no-audit $FORMULA

--- a/bump-version.sh
+++ b/bump-version.sh
@@ -20,4 +20,4 @@ then
 fi
 
 # note: --write-only flag here means that it doesn't open a PR
-brew bump-formula-pr --write-only --version $NEW_VERSION --no-fork --no-audit $FORMULA
+brew bump-formula-pr --write-only --version $NEW_VERSION $FORMULA

--- a/bump-version.sh
+++ b/bump-version.sh
@@ -19,4 +19,4 @@ then
 	exit 0
 fi
 
-brew bump-formula-pr --write-only --version $NEW_VERSION --no-fork --no-audit $FORMULA
+brew bump-formula-pr --write-only --version $NEW_VERSION --no-audit $FORMULA

--- a/bump-version.sh
+++ b/bump-version.sh
@@ -19,4 +19,4 @@ then
 	exit 0
 fi
 
-brew bump-formula-pr --write-only --version $NEW_VERSION $FORMULA
+brew bump-formula-pr --write-only --version $NEW_VERSION --no-fork $FORMULA

--- a/fake-tap.sh
+++ b/fake-tap.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# fake-tap.sh -- this symlinks the checkout directory to a tap in a fresh homebrew/brew docker image,
+# and does other setup.
+
+set -eux
+
+CHECKOUT_DIR=${CHECKOUT_DIR:-$PWD}
+# not sure homebrew specifies this in docs; I got by doing:
+# `find $(brew --prefix) | grep viam-server.rb`
+TAP_DIR=$(brew --prefix)/Homebrew/Library/Taps/viamrobotics
+
+mkdir $TAP_DIR
+ln -s $CHECKOUT_DIR $TAP_DIR/homebrew-brews
+git config --global --add safe.directory '*'
+git config --global url."https://github.com/".insteadOf git@github.com:
+brew developer on


### PR DESCRIPTION
## What changed
- pin to last week's brew image + disable auto-update
- refactor brew setup step in yml to `fake-tap.sh` so people can run locally for debugging
- (incidental) the autobump ran in this branch
## Why
It seems like the `--write-only` flag in the bump PR changed or broke and our stuff stopped working