### PR TITLE
make nlopt-static a build-time dep

### DIFF
--- a/Formula/viam-server.rb
+++ b/Formula/viam-server.rb
@@ -17,9 +17,9 @@ class ViamServer < Formula
   depends_on "go" => :build
   depends_on "node@20" => :build
   depends_on "pkg-config" => :build
+  depends_on "nlopt-static" => :build
   depends_on "ffmpeg"
   depends_on "jpeg-turbo"
-  depends_on "nlopt-static"
   depends_on "opus"
   depends_on "x264"
 


### PR DESCRIPTION
## What changed
- move nlopt-static to a `:build` dep in viam-server formula
## Why
Currently users have to build nlopt-static even when downloading a bottle. This is 1) redundant, but 2) increases the odds that something goes wrong; without nlopt-static, nothing gets compiled in bottle mode I believe. An in-house user today ran into trouble today that would have been avoided if nlopt-static were omitted.
## Manual test
I made this change on my local tap and verified that nlopt wasn't built.
## Follow-up work
Some or all of the other libraries are also not runtime deps (but at least don't require a build, as otterverse points out).