### PR TITLE
APP 6503 Removing service block

### DIFF
--- a/Formula/viam-server.rb
+++ b/Formula/viam-server.rb
@@ -49,9 +49,6 @@ class ViamServer < Formula
     <<~EOS
       Note that when installed via homebrew, the default location for the viam-server config is
       #{HOMEBREW_PREFIX}/etc/viam.json
-
-      To manage viam-server as a service, use brew's service command. Run the following for more info:
-      # brew services --help
     EOS
   end
 end


### PR DESCRIPTION
This change removes the `service` config block in order to silence one of the two lines of start/run instructions that are output at the end of the `brew install` process.

https://viam.atlassian.net/browse/APP-6503