### PR TITLE
Prevent root installation on Mac

### DIFF
--- a/Formula/viam-server.rb
+++ b/Formula/viam-server.rb
@@ -6,6 +6,8 @@ class ViamServer < Formula
   license "AGPL-3.0"
   head "https://github.com/viamrobotics/rdk.git", branch: "main"
 
+  requires_root(:forbidden) if OS.mac?
+
   bottle do
     root_url "https://ghcr.io/v2/viamrobotics/brews"
     rebuild 37

--- a/Formula/viam-server.rb
+++ b/Formula/viam-server.rb
@@ -19,9 +19,9 @@ class ViamServer < Formula
   depends_on "go" => :build
   depends_on "node@20" => :build
   depends_on "pkg-config" => :build
-  depends_on "nlopt-static"
   depends_on "ffmpeg"
   depends_on "jpeg-turbo"
+  depends_on "nlopt-static"
   depends_on "opus"
   depends_on "x264"
 

--- a/Formula/viam-server.rb
+++ b/Formula/viam-server.rb
@@ -6,8 +6,6 @@ class ViamServer < Formula
   license "AGPL-3.0"
   head "https://github.com/viamrobotics/rdk.git", branch: "main"
 
-  requires_root(:forbidden) if OS.mac?
-
   bottle do
     root_url "https://ghcr.io/v2/viamrobotics/brews"
     rebuild 37
@@ -26,6 +24,10 @@ class ViamServer < Formula
   depends_on "x264"
 
   def install
+    if OS.mac? && Process.uid.zero?
+      odie "viam-server should not be installed with sudo on macOS. Please run: brew install viam-server"
+    end
+
     with_env(
       "TAG_VERSION" => "v#{version}",
     ) do

--- a/Formula/viam.rb
+++ b/Formula/viam.rb
@@ -5,6 +5,8 @@ class Viam < Formula
   sha256 "79b072259520e428cbe53eccdfeec9aafd8e5509614fcef3a51c22abc0ca2a40"
   head "https://github.com/viamrobotics/rdk.git", branch: "main"
 
+  requires_root(:forbidden) if OS.mac?
+
   bottle do
     root_url "https://ghcr.io/v2/viamrobotics/brews"
     rebuild 37

--- a/Formula/viam.rb
+++ b/Formula/viam.rb
@@ -5,8 +5,6 @@ class Viam < Formula
   sha256 "79b072259520e428cbe53eccdfeec9aafd8e5509614fcef3a51c22abc0ca2a40"
   head "https://github.com/viamrobotics/rdk.git", branch: "main"
 
-  requires_root(:forbidden) if OS.mac?
-
   bottle do
     root_url "https://ghcr.io/v2/viamrobotics/brews"
     rebuild 37
@@ -18,6 +16,10 @@ class Viam < Formula
   depends_on "go" => :build
 
   def install
+    if OS.mac? && Process.uid.zero?
+      odie "viam should not be installed with sudo on macOS. Please run: brew install viam"
+    end
+
     ENV["TAG_VERSION"] = version
     system("make", "cli-ci")
     bin.install Dir["bin/*/viam-cli"][0] => "viam"


### PR DESCRIPTION
brew will return a clear error if you try to install viam-server or viam with `sudo`. 

FWIW brew normally also tries to prevent to run with sudo

```shell
$ sudo brew install viamrobotics/brews/viam                                                                                                 [10:49:16]
Password:
Error: Running Homebrew as root is extremely dangerous and no longer supported.
As Homebrew does not drop privileges on installation you would be giving all
build scripts full access to your system.
FAIL
```