### PR TITLE
Add livecheck regex to viam-server formula

### DIFF
--- a/Formula/viam-server.rb
+++ b/Formula/viam-server.rb
@@ -6,6 +6,11 @@ class ViamServer < Formula
   license "AGPL-3.0"
   head "https://github.com/viamrobotics/rdk.git", branch: "main"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     root_url "https://ghcr.io/v2/viamrobotics/brews"
     rebuild 65


### PR DESCRIPTION
The bump-versions workflow was failing because homebrew's default livecheck matched a stray non-semver tag (2-arms-2-pipelines) in the rdk repo. The regex restricts livecheck to stable semver tags only.