### PR TITLE
Fix bump scripts matching PR titles containing "livecheck"

### DIFF
--- a/bump-version.sh
+++ b/bump-version.sh
@@ -2,22 +2,22 @@
 
 FORMULA=$1
 
-if [ -z $FORMULA ]
+if [ -z "$FORMULA" ]
 then
 	echo "Formula name missing or invalid"
 	exit 1
 fi
 
 CHECK=$(brew bump $FORMULA)
-CUR_VERSION=$(echo "$CHECK" | grep Current | awk '{print $4}')
-NEW_VERSION=$(echo "$CHECK" | grep livecheck | awk '{print $4}')
+CUR_VERSION=$(echo "$CHECK" | grep "Current formula version" | awk '{print $4}')
+NEW_VERSION=$(echo "$CHECK" | grep "livecheck version" | awk '{print $4}')
 
 echo -e "$CHECK"
 
-if [ $CUR_VERSION = $NEW_VERSION ]
+if [ "$CUR_VERSION" = "$NEW_VERSION" ]
 then
 	exit 0
 fi
 
 # note: --write-only flag here means that it doesn't open a PR
-brew bump-formula-pr --write-only --version $NEW_VERSION $FORMULA
+brew bump-formula-pr --write-only --version "$NEW_VERSION" "$FORMULA"

--- a/needs-bump.sh
+++ b/needs-bump.sh
@@ -5,17 +5,17 @@ set -eu
 
 FORMULA=${1-}
 
-if [ -z $FORMULA ]
+if [ -z "$FORMULA" ]
 then
 	echo "Formula name missing or invalid"
 	exit 1
 fi
 
 CHECK=$(brew bump --no-fork --no-pull-requests $FORMULA)
-CUR_VERSION=$(echo "$CHECK" | grep Current | awk '{print $4}')
-NEW_VERSION=$(echo "$CHECK" | grep livecheck | awk '{print $4}')
+CUR_VERSION=$(echo "$CHECK" | grep "Current formula version" | awk '{print $4}')
+NEW_VERSION=$(echo "$CHECK" | grep "livecheck version" | awk '{print $4}')
 
-if [ $CUR_VERSION = $NEW_VERSION ]
+if [ "$CUR_VERSION" = "$NEW_VERSION" ]
 then
 	echo "false"
 else


### PR DESCRIPTION
`grep livecheck` matched both the version line and a "Maybe duplicate pull requests" line whose PR title contained the word "livecheck", making NEW_VERSION multi-line. This broke the unquoted test expression and passed garbage arguments to brew bump-formula-pr.

Tighten grep patterns and quote all variable expansions.