### PR TITLE
Fix brew audit rubocop failure in bump-version.sh

### DIFF
--- a/Formula/viam-server.rb
+++ b/Formula/viam-server.rb
@@ -1,8 +1,8 @@
 class ViamServer < Formula
   desc "Main server application of the viam robot development kit (RDK)"
   homepage "https://www.viam.com/"
-  url "https://github.com/viamrobotics/rdk/archive/refs/tags/v0.119.2.tar.gz"
-  sha256 "ca8f94f6c37b5d660e14ac9f0f5b0c572754e972a1d38f8033bddc5a3cafd4e1"
+  url "https://github.com/viamrobotics/rdk/archive/refs/tags/v0.121.0.tar.gz"
+  sha256 "c72570d70cff9c1bc82cda6d45791d143d723fe6ffbaf4a2876a4a912fde87bc"
   license "AGPL-3.0"
   head "https://github.com/viamrobotics/rdk.git", branch: "main"
 

--- a/Formula/viam-server.rb
+++ b/Formula/viam-server.rb
@@ -13,10 +13,9 @@ class ViamServer < Formula
 
   bottle do
     root_url "https://ghcr.io/v2/viamrobotics/brews"
-    rebuild 65
-    sha256 cellar: :any,                 arm64_sequoia: "94104323c3fa67d144e3a2b3bce7bd995173b554f0eabcafd123d6b95328fd0f"
-    sha256 cellar: :any,                 arm64_sonoma:  "2d4b5d7aee5b0f6079ec721dc89a54e7be40a4af1696a2508955a319e07c91d2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "df7457083347bb542a8311459aeec4a83a8bf302a800fd6a93f1b7cbe13b4fc8"
+    sha256 cellar: :any,                 arm64_sequoia: "4603afa85becc1e81d3bb6b8cd67f5f80754295ef6d21a6c628fa209890ec393"
+    sha256 cellar: :any,                 arm64_sonoma:  "cc083adcead8a0279ef8a6f0e9be557ac790b98a362c3cb9e6253c356acb9fce"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "4d3ca51d14dfcfb4f658dd21a739fbbc0919fb413848447bcb6736d1b8362be9"
   end
 
   depends_on "go" => :build

--- a/Formula/viam.rb
+++ b/Formula/viam.rb
@@ -1,8 +1,8 @@
 class Viam < Formula
   desc "CLI for managing robots, orgs, etc. (See viam-server for running a robot)"
   homepage "https://docs.viam.com/cli/"
-  url "https://github.com/viamrobotics/rdk/archive/refs/tags/v0.119.2.tar.gz"
-  sha256 "ca8f94f6c37b5d660e14ac9f0f5b0c572754e972a1d38f8033bddc5a3cafd4e1"
+  url "https://github.com/viamrobotics/rdk/archive/refs/tags/v0.121.0.tar.gz"
+  sha256 "c72570d70cff9c1bc82cda6d45791d143d723fe6ffbaf4a2876a4a912fde87bc"
   license "AGPL-3.0"
   head "https://github.com/viamrobotics/rdk.git", branch: "main"
 

--- a/Formula/viam.rb
+++ b/Formula/viam.rb
@@ -13,10 +13,9 @@ class Viam < Formula
 
   bottle do
     root_url "https://ghcr.io/v2/viamrobotics/brews"
-    rebuild 65
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "e3b96eb87548c0e9fa312d8a6824dcfeb1a1f5a8d0b76bee7e57ff5c52f222cd"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "fab4ac3770823673575461de1daac0c2e5293a6a0b630b97bc940781f1961810"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "a18e087b5b892a9db788234c0804085c30445bee62ccb94a7ff434e0a6ec930c"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "9e47f95408e6b03e6f46d76f1eab9a2de8297f0fec9f6360057c6a7d92739db4"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "96422e987cc5cd03b58e6e4d2574970a77b0ecdaf8c4e4bab65d81dd6634c36b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "256123f223be2155ee19b9884d9b1e7cb664ffaf48751293ae1ab2c62224ce05"
   end
 
   depends_on "go" => :build

--- a/bump-version.sh
+++ b/bump-version.sh
@@ -20,4 +20,6 @@ then
 fi
 
 # note: --write-only flag here means that it doesn't open a PR
-brew bump-formula-pr --write-only --version "$NEW_VERSION" "$FORMULA"
+# --no-audit: skip brew audit (rubocop) which fails on the pinned container;
+# formulas are validated during the bottle step anyway
+brew bump-formula-pr --write-only --no-audit --version "$NEW_VERSION" "$FORMULA"


### PR DESCRIPTION
The pinned homebrew/brew container image ships a RuboCop config that references `Performance` cops extracted to a separate gem, causing `brew audit` to exit with code 2. This was a latent bug — it was never triggered until now because viam-server only got a livecheck block on Apr 2, and no new RDK version was released until today (v0.121.0). Once livecheck detected a version mismatch, bump-version.sh called `brew bump-formula-pr` for the first time with this container, hitting the broken RuboCop config.

Skip the audit with --no-audit since formulas are validated during the bottle step anyway (bottle.yml runs a full `brew install`).