### PR TITLE
revert v999

### DIFF
--- a/Formula/viam-server.rb
+++ b/Formula/viam-server.rb
@@ -1,8 +1,8 @@
 class ViamServer < Formula
   desc "Main server application of the viam robot development kit (RDK)"
   homepage "https://www.viam.com/"
-  url "https://github.com/viamrobotics/rdk/archive/refs/tags/v999.999.999.tar.gz"
-  sha256 "36239478b662c72328b57dba8ebf20b4211f18920bfd3574fd4aefe579de446e"
+  url "https://github.com/viamrobotics/rdk/archive/refs/tags/v0.129.0.tar.gz"
+  sha256 "c89195e941e403dfd69d39c6cf0703fc89377fbd3b63f1a3092fac58e7299552"
   license "AGPL-3.0"
   head "https://github.com/viamrobotics/rdk.git", branch: "main"
 
@@ -13,10 +13,10 @@ class ViamServer < Formula
 
   bottle do
     root_url "https://ghcr.io/v2/viamrobotics/brews"
-    rebuild 13
-    sha256 cellar: :any,                 arm64_sequoia: "026295b2c78f371128bcbb5ab5e345073e9ee16de64ffe5e9aa82c3f33ad23bc"
-    sha256 cellar: :any,                 arm64_sonoma:  "e2a69afb27596036168085fb27a472d2f43df75f4cea94b21128ba8dde2d0108"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "15e36dcb050d3b383411f38075e89c376fbae636f370fa0adc19012cc8d4a564"
+    rebuild 12
+    sha256 cellar: :any,                 arm64_sequoia: "5fecc3d9f6730e2c25fc71e8b46d5ae8fd2d2331af231b61be798f323c0fac19"
+    sha256 cellar: :any,                 arm64_sonoma:  "913ab8af9cea7ee941e33877c3d6702f91652ca0d12b1258daac070e9ef5fc9d"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "14b0b29152dab940f3ae9b7e36d86ec49c687d8aa9074e3ad9d292446fdcdd3c"
   end
 
   depends_on "go" => :build

--- a/Formula/viam.rb
+++ b/Formula/viam.rb
@@ -1,8 +1,8 @@
 class Viam < Formula
   desc "CLI for managing robots, orgs, etc. (See viam-server for running a robot)"
   homepage "https://docs.viam.com/cli/"
-  url "https://github.com/viamrobotics/rdk/archive/refs/tags/v999.999.999.tar.gz"
-  sha256 "36239478b662c72328b57dba8ebf20b4211f18920bfd3574fd4aefe579de446e"
+  url "https://github.com/viamrobotics/rdk/archive/refs/tags/v0.129.0.tar.gz"
+  sha256 "c89195e941e403dfd69d39c6cf0703fc89377fbd3b63f1a3092fac58e7299552"
   license "AGPL-3.0"
   head "https://github.com/viamrobotics/rdk.git", branch: "main"
 
@@ -13,10 +13,10 @@ class Viam < Formula
 
   bottle do
     root_url "https://ghcr.io/v2/viamrobotics/brews"
-    rebuild 13
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "798f911d922203675b0f73189c0864f4fcd07ebe1d8952155a9a277430e71a6e"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "af52e277c1ca3367df655d0ff99f1653570777a1d5d107340e8d3cc56b528ed9"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "e0ba81b15f41fdb524987198cf54afe48a23806c944d59a18be53bb76c0b233a"
+    rebuild 12
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "c0141bc82c59228adf84fc3ead585c2f4957969119a0a8d5dc742480359e833a"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "f29c3301b5525123e17d304ab8e789a8c7299b6b4d56e4664101390f2af5a420"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "e77c23089f131c9444aefc7af10bf140432e58c800a9606e3d8cdc88d608739c"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
## What changed
revert livecheck update to deleted v999 tag
## Why
livecheck seems broken now (404ing on 'vunable' = version unable)